### PR TITLE
(SIMP-252) Cast ima_audit to a string.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ begin
   PuppetLint.configuration.send("disable_80chars")
   PuppetLint.configuration.send("disable_variables_not_enclosed")
   PuppetLint.configuration.send("disable_class_parameter_defaults")
+  PuppetLint.configuration.send('disable_only_variable_string')
 rescue LoadError
   puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
 end

--- a/build/pupmod-tpm.spec
+++ b/build/pupmod-tpm.spec
@@ -1,7 +1,7 @@
 Summary: TPM Puppet Module
 Name: pupmod-tpm
 Version: 0.0.1
-Release: 6
+Release: 7
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -61,6 +61,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Jul 09 2015 Nick Markowski <nmarkowski@kewcorp.com> - 0.0.1-7
+- Cast ima_audit to string when passed to kernel_parameter.
+
 * Thu Feb 19 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-6
 - Migrated to the new 'simp' environment.
 

--- a/manifests/ima.pp
+++ b/manifests/ima.pp
@@ -67,7 +67,7 @@ class tpm::ima (
     }
 
     kernel_parameter { 'ima_audit':
-      value    => $ima_audit,
+      value    => "$ima_audit",
       bootmode => 'normal'
     }
 


### PR DESCRIPTION
Kernel_parameter does not take a boolean, it needs to be
a string.

SIMP-252 #close Cast ima_audit to string.