### PR TITLE
(SIMP-265) Disable IMA by default

### DIFF
--- a/build/pupmod-tpm.spec
+++ b/build/pupmod-tpm.spec
@@ -1,7 +1,7 @@
 Summary: TPM Puppet Module
 Name: pupmod-tpm
 Version: 0.0.1
-Release: 7
+Release: 8
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -61,6 +61,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-8
+- Disable IMA by default.
+
 * Thu Jul 09 2015 Nick Markowski <nmarkowski@kewcorp.com> - 0.0.1-7
 - Cast ima_audit to string when passed to kernel_parameter.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # == Class: tpm
 #
-# Sets up tpm
+# Provides utilities for interacting with a TPM
 #
 # == Parameters
 #
@@ -12,7 +12,7 @@
 # * Nick Markowski <nmarkowski@keywcorp.com>
 #
 class tpm (
-  $use_ima = true
+  $use_ima = false
 ){
   # Check if the system has a TPM (which also checks that it
   # is a physical machine, and if so install tools and setup

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,14 +41,6 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
   c.mock_framework = :rspec
   c.mock_with :mocha


### PR DESCRIPTION
While interesting and useful, IMA does add load to a system without
providing an active defense mechanism, therefore it is being disabled by
default.

SIMP-265 #close #comment Disable IMA by default