### PR TITLE
Initial tboot commit

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,6 +13,16 @@ derivatives thereof, pursuant to the contracts under which it was developed and
 the License under which it falls.
 
 ---
+tboot.pp
+
+Intel(R) TXT Trusted Boot Module - Puppet module for configuring tboot
+
+   Copyright (C) 2015 Silicon Graphics International Corp.
+   All Rights Reserved.
+
+     Jacob Gingrich <gingrich@sgi.com>
+
+---
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/dis
 Please excuse us as we transition this code into the public domain.
 
 Downloads, discussion, and patches are still welcome!
+
+### tboot.pp
+#
+# The tpm::tboot class is disabled by default. You will need to add the class and set enable to true. When enabled it will look for the "has_tpm" fact and the version of Enterprise Linux. If it is version 6 or version 7 it will install the tboot RPM and setup grub for trusted boot. A reboot is required to enter tboot mode. If tboot was successful PCR 17-19 will be populated with real hash values. Developement information of Intel(R) TXT can be found here: http://www.intel.com/content/dam/www/public/us/en/documents/guides/intel-txt-software-development-guide.pdf. 
+#
+###

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -1,0 +1,97 @@
+# == Class: tpm::tboot
+#
+# Sets up Intel TXT Trusted Boot (tboot) if TPM chip is installed on system.
+# Configures legacy grub and grub2 depending on the OS Version.
+# This has been tested on Systems that use Intel TXT compatible TPM chips.
+#
+# This module will break the functionality of the augeasproviders_grub
+# because it moves the kernel perameters to modules. If you are using this
+# provider it will need to be done a different way by using the general "augeas"
+# as is done in this module.
+#
+# An example to remove kernel rhgb optioni using augeas instead of 'kernel_perameter'.
+#    augeas { 'grub.conf/no_rhgb':
+#        incl    => '/boot/grub/grub.conf',
+#        lens    => 'grub.lns',
+#        changes => 'rm  title[*]/kernel/rhgb',
+#    }
+#
+#
+# == Parameters
+#
+# [*enable*]
+#   Type: Boolean
+#   Default: false
+#     If true, enable Trustedboot on the system.
+#
+# == Authors
+#
+# * Jacob Gingrich <gingrich@sgi.com>
+#
+class tpm::tboot (
+  $enable = false,
+){
+
+  if $enable {
+    if  ( $::operatingsystem in ['RedHat','CentOS'] ) and str2bool($::has_tpm) {
+
+      package { ['tboot','trousers']:
+        ensure => 'present',
+      }
+
+      if ( $::lsbmajdistrelease == '6' ) {
+        
+        augeas { 'grub.conf/mvkernel':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => 'mv title[*]/kernel title[*]/module[1]',
+          onlyif  => "match title[*]/kernel[.='/tboot.gz'] size == 0",
+          require => Package['tboot'],
+        }
+
+        augeas { 'grub.conf/mvinitrd':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => 'mv title[*]/initrd title[*]/module[2]',
+          onlyif  => 'get title[*][count(initrd)] > 0',
+          require => [ Package['tboot'], Augeas['grub.conf/mvkernel']],
+        }
+
+        augeas { 'grub.conf/kernel':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => [
+            'ins kernel before title[*]/module[1]',
+            "set title[*]/kernel '/tboot.gz'",
+            "setm title[*]/kernel logging 'serial,vga,memory'",
+            ],
+          onlyif  => 'match title[*]/kernel size == 0',
+          require => [ Package['tboot'], Augeas['grub.conf/mvkernel'], Augeas['grub.conf/mvinitrd']],
+        }
+      }
+
+      if ( $::lsbmajdistrelease == '7' ) {
+
+        exec { 'add-tboot-menu':
+          command => '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg',
+          unless  => '/usr/bin/grep tboot /boot/grub2/grub.cfg',
+          require => Package['tboot'],
+        }
+
+        exec { 'normalize-tboot-menu':
+          command => "/usr/bin/sed -i 's/tboot.*{/tboot {/' /boot/grub2/grub.cfg",
+          onlyif  => "/usr/bin/grep 'submenu.*tboot [0-9.0-9.0-9]' /boot/grub2/grub.cfg",
+          require => [ Package['tboot'], Exec['add-tboot-menu']],
+        }
+
+        exec { 'set-default-boot':
+          command => '/usr/sbin/grub2-set-default tboot',
+          unless  => '/usr/bin/grep tboot /boot/grub2/grubenv',
+          require => [ Package['tboot'], Exec['add-tboot-menu'], Exec['normalize-tboot-menu']],
+        }
+      }
+    }
+  }
+
+  validate_bool($enable)
+}


### PR DESCRIPTION
This is the first commit of the tboot.pp manifest. It install Intel(R) TXT Trusted Boot (tboot) and configures grub (legacy) in EL6 and grub2 in EL7 to boot to tboot.gz. 