### PR TITLE
(SIMP-446) Add tboot module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,6 +13,16 @@ derivatives thereof, pursuant to the contracts under which it was developed and
 the License under which it falls.
 
 ---
+tboot.pp
+
+Intel(R) TXT Trusted Boot Module - Puppet module for configuring tboot
+
+   Copyright (C) 2015 Silicon Graphics International Corp.
+   All Rights Reserved.
+
+     Jacob Gingrich <gingrich@sgi.com>
+
+---
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ If you find any issues, they can be submitted to our [JIRA](https://simp-project
 
 Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP) and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
 
+## tboot.pp
+The tpm::tboot class is disabled by default. You will need to add "tpm::use_tboot: true" to your hieradata. When enabled it will look for the "has_tpm" fact and the version of Enterprise Linux. If it is version 6 or version 7 it will install the tboot RPM and setup grub for trusted boot. A reboot is required to enter tboot mode. If tboot was successful PCR 17-19 will be populated with real hash values. When tpm::use_tboot: is true and tpm::tboot::enable : is false, the module will uninstall the tboot RPM and reset grub to a non-tboot kernel.
+Developement information of Intel(R) TXT can be found here: http://www.intel.com/content/dam/www/public/us/en/documents/guides/intel-txt-software-development-guide.pdf.
+
 ## Work in Progress
 
 Please excuse us as we transition this code into the public domain.
 
 Downloads, discussion, and patches are still welcome!
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,12 +7,16 @@
 # [*use_ima*]
 #   Boolean.  Toggles IMA on or off.
 #
+# [*use_tboot*]
+#   Boolean.  Toggles tboot on or off.
+#
 # == Authors
 #
 # * Nick Markowski <nmarkowski@keywcorp.com>
 #
 class tpm (
-  $use_ima = false
+  $use_ima = false,
+  $use_tboot = false
 ){
   # Check if the system has a TPM (which also checks that it
   # is a physical machine, and if so install tools and setup
@@ -31,5 +35,9 @@ class tpm (
 
   if $use_ima {
     include '::tpm::ima'
+  }
+
+  if $use_tboot {
+    include '::tpm::tboot'
   }
 }

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -1,0 +1,165 @@
+# == Class: tpm::tboot
+#
+# Sets up Intel TXT Trusted Boot (tboot) if TPM chip is installed on system.
+# Configures legacy grub and grub2 depending on the OS Version.
+# This has been tested on Systems that use Intel TXT compatible TPM chips.
+#
+# This module will break the functionality of the augeasproviders_grub
+# because it moves the kernel parameters to modules. If you are using this
+# provider it will need to be done a different way by using the general "augeas"
+# as is done in this module.
+#
+# An example to remove kernel rhgb option using augeas instead of 'kernel_parameter'.
+#    augeas { 'grub.conf/no_rhgb':
+#        incl    => '/boot/grub/grub.conf',
+#        lens    => 'grub.lns',
+#        changes => 'rm  title[*]/kernel/rhgb',
+#    }
+#
+#
+# == Parameters
+#
+# [*enable*]
+#   Type: Boolean
+#   Default: true
+#     If true, enable Trustedboot on the system.
+#     If false, disable Trustedboot on the system.
+#
+# == Authors
+#
+# * Jacob Gingrich <gingrich@sgi.com>
+#
+class tpm::tboot (
+  $enable = true,
+){
+
+  validate_bool($enable)
+
+  if $enable {
+    if  ( $::operatingsystem in ['RedHat','CentOS'] ) and str2bool($::has_tpm) {
+
+      package { ['tboot','trousers']:
+        ensure => 'present',
+      }
+
+      if ( $::operatingsystemmajrelease == '6' ) {
+
+        exec { 'backup-grub-conf':
+          command => '/bin/cp --backup=numbered /boot/grub/grub.conf /boot/grub/grub.conf.puppet-bak',
+          unless  => '/usr/bin/diff /boot/grub/grub.conf /boot/grub/grub.conf.puppet-bak',
+        }
+
+        augeas { 'grub.conf/mvkernel':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => 'mv title[*]/kernel title[*]/module[1]',
+          onlyif  => "match title[*]/kernel[.='/tboot.gz'] size == 0",
+          require => [ Package['tboot'], Exec['backup-grub-conf']],
+        }
+
+        augeas { 'grub.conf/mvinitrd':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => 'mv title[*]/initrd title[*]/module[2]',
+          onlyif  => 'get title[*][count(initrd)] > 0',
+          require => [ Package['tboot'], Augeas['grub.conf/mvkernel'], Exec['backup-grub-conf']],
+        }
+
+        augeas { 'grub.conf/kernel':
+          incl    => '/boot/grub/grub.conf',
+          lens    => 'grub.lns',
+          changes => [
+            'ins kernel before title[*]/module[1]',
+            "set title[*]/kernel '/tboot.gz'",
+            "setm title[*]/kernel logging 'serial,vga,memory'",
+            ],
+          onlyif  => 'match title[*]/kernel size == 0',
+          require => [ Package['tboot'], Augeas['grub.conf/mvkernel'], Exec['backup-grub-conf'], Augeas['grub.conf/mvinitrd']],
+        }
+      }
+
+      if ( $::operatingsystemmajrelease == '7' ) {
+
+        exec { 'add-tboot-menu':
+          command => '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg',
+          unless  => '/usr/bin/grep tboot /boot/grub2/grub.cfg',
+          require => Package['tboot'],
+        }
+
+        file_line { 'normalize-tboot-menu':
+          path     => '/boot/grub2/grub.cfg',
+          line     => 'submenu tboot {',
+          match    => '^submenu.*tboot.*[0-9.0-9.0-9].*{',
+          multiple => false,
+          require  => [ Package['tboot'], Exec['add-tboot-menu']],
+        }
+
+        exec { 'set-default-boot':
+          command => '/usr/sbin/grub2-set-default tboot',
+          unless  => '/usr/bin/grep saved_entry=tboot /boot/grub2/grubenv',
+          require => [ Package['tboot'], Exec['add-tboot-menu'], File_line['normalize-tboot-menu']],
+        }
+      }
+    }
+  }
+
+  else {
+
+    if ( $::operatingsystemmajrelease == '6' ) {
+
+      exec { 'backup-grub-conf':
+        command => '/bin/cp --backup=numbered /boot/grub/grub.conf /boot/grub/grub.conf.puppet-bak',
+        unless  => '/usr/bin/diff /boot/grub/grub.conf /boot/grub/grub.conf.puppet-bak',
+      }
+
+      augeas { 'grub.conf/rmkernel':
+        incl    => '/boot/grub/grub.conf',
+        lens    => 'grub.lns',
+        changes => 'rm title[*]/kernel',
+        onlyif  => "match title[*]/kernel[.='/tboot.gz'] size > 0",
+        require => Exec['backup-grub-conf'],
+      }
+
+      augeas { 'grub.conf/kernel':
+        incl    => '/boot/grub/grub.conf',
+        lens    => 'grub.lns',
+        changes => 'mv title[*]/module[1] title[*]/kernel',
+        onlyif  => 'match title[*]/kernel size == 0',
+        require => [ Augeas['grub.conf/rmkernel'], Exec['backup-grub-conf']],
+      }
+
+      augeas { 'grub.conf/mvinitrd':
+        incl    => '/boot/grub/grub.conf',
+        lens    => 'grub.lns',
+        changes => 'mv title[*]/module[1] title[*]/initrd',
+        onlyif  => 'match title[*]/initrd size == 0',
+        require => [ Augeas['grub.conf/rmkernel'], Exec['backup-grub-conf'], Augeas['grub.conf/kernel']],
+      }
+
+      package { ['tboot']:
+        ensure  => 'absent',
+        require => [ Augeas['grub.conf/kernel'], Augeas['grub.conf/rmkernel'], Exec['backup-grub-conf'], Augeas['grub.conf/mvinitrd']],
+      }
+    }
+
+    if ( $::operatingsystemmajrelease == '7' ) {
+
+      exec { 'remove-default-tboot':
+        command => '/usr/sbin/grub2-set-default 0',
+        onlyif  => '/usr/bin/grep saved_entry=tboot /boot/grub2/grubenv',
+      }
+
+      package { ['tboot']:
+        ensure  => 'absent',
+        require => Exec['remove-default-tboot'],
+      }
+
+      exec { 'remove-tboot-menu':
+        command => '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg',
+        onlyif  => '/usr/bin/grep tboot /boot/grub2/grub.cfg',
+        require => [ Package['tboot'], Exec['remove-default-tboot']],
+      }
+    }
+  }
+
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'tpm' do
 
   let(:params) {{
-    :use_ima => true
+    :use_ima => true,
+    :use_tboot => true
   }}
 
   let(:facts) {{
@@ -15,5 +16,6 @@ describe 'tpm' do
   it { should compile.with_all_deps }
   it { should create_class('tpm') }
   it { should contain_class('tpm::ima') }
+  it { should contain_class('tpm::tboot') }
 
 end

--- a/spec/classes/tboot_spec.rb
+++ b/spec/classes/tboot_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'tpm::tboot' do
+
+  let(:facts) {{
+    :operatingsystem => 'RedHat',
+    :operatingsystemmajrelease => '7'
+  }}
+
+  it { should compile.with_all_deps }
+  it { should create_class('tpm::tboot') }
+
+  context 'enabling_tboot' do
+
+    let(:facts) {{
+      :cmdline => { 'foo' => 'bar' },
+      :has_tpm => 'true',
+      :operatingsystem => 'RedHat',
+      :operatingsystemmajrelease => '7'
+    }}
+
+    it { should compile.with_all_deps }
+    it { should contain_package('tboot') }
+
+  end
+
+  context 'disabling_tboot' do
+    let(:params) {{ :enable => false }}
+
+    it { should compile.with_all_deps }
+    it { should contain_package('tboot').with_ensure('absent') }
+
+  end
+end


### PR DESCRIPTION
This module will install tboot and setup grub for Trusted boot.
It will also uninstall tboot and revert grub if enable is set to
false. Spec tests have been added.

SIMP-446 #close #comment Add tboot module
