### PR TITLE
(SIMP-1518) Change SRK password default to null

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Sep 27 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.2.0-0
+- Added functionality to take ownership of the TPM
+
 * Tue Mar 01 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 0.0.1-10
 - Added compliance function support
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,17 @@ In order to use the TPM module or a TPM in general, you must do the following:
 
 ### Beginning with the TPM module
 
-Include the TPM class and set the passwords in hieradata:
+--------------------------------------------------------------------------------
+> **NOTE**
+>
+> Setting the SRK password to an empty string is not recommended for actual use,
+> but it is required for both Intel TXT (Trusted Boot) and the [PKCS#11
+> interface](http://trousers.sourceforge.net/pkcs11.html). If you aren't using
+> either of those technologies, please use a real password.
+
+--------------------------------------------------------------------------------
+
+Include the TPM class and set the passwords in hiera:
 
 ```yaml
 classes:
@@ -90,6 +100,9 @@ classes:
 
 tpm::take_ownership: true
 tpm::ownership::advanced_facts: true
+
+tpm::ownership::owner_pass: 'badpass'
+tpm::ownership::srk_pass: ''
 ```
 
 To enable IMA, add this line to hiera:

--- a/lib/facter/tpm.rb
+++ b/lib/facter/tpm.rb
@@ -12,23 +12,6 @@ Facter.add('tpm') do
   confine :has_tpm => true
   # confine :true => ! (`puppet resource service tcsd | grep running`.eql? "")
 
-  # There is sometimes an unprinted unicode character captured from the command lines
-  #   in older versions of ruby, we need to do this encoding nonsense. In ruby 2.1+,
-  #   the String#scrub method can be used.
-  #
-  # @param [String] the string to be cleaned
-  # @return [String] string with non-acii characters removed
-  #
-  def clean_text(text)
-    encoding_options = {
-      :invalid           => :replace,  # Replace invalid byte sequences
-      :undef             => :replace,  # Replace anything not defined in ASCII
-      :replace           => '',        # Use a blank for those replacements
-      :universal_newline => true       # Always break lines with \n
-    }
-    text.encode(Encoding.find('ASCII'), encoding_options).gsub(/\u0000/, '')
-  end
-
   # Get the pubek from tpm_getpubek when the TPM is owned
   # @param [String] the owner password of the TPM
   # @return [String] the output of the command, or nil if it times out
@@ -124,7 +107,7 @@ Facter.add('tpm') do
       output['_status'] = 'Trousers is not running'
       return output
     else
-      version = YAML.load(clean_text(cmd_out))
+      version = YAML.load(cmd_out)
 
       # Format keys in a way that Facter will like
       begin
@@ -216,11 +199,7 @@ Facter.add('tpm') do
   end
 
   setcode do
-    if Facter.value(:os)['release']['major'] == 6
-      @sys_path = '/sys/class/misc/tpm0'
-    else
-      @sys_path = '/sys/class/tpm/tpm0'
-    end
+    @sys_path = '/sys/class/tpm/tpm0'
 
     out = Hash.new
 

--- a/lib/puppet/provider/tpm_ownership/trousers.rb
+++ b/lib/puppet/provider/tpm_ownership/trousers.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:tpm_ownership).provide :trousers do
 
   defaultfor :kernel => :Linux
 
-  commands :tpm_takeownership => '/sbin/tpm_takeownership'
+  commands :tpm_takeownership => 'tpm_takeownership'
 
   # Dump the owner password to a flat file in Puppet's `$vardir`
   #
@@ -41,7 +41,7 @@ Puppet::Type.type(:tpm_ownership).provide :trousers do
   # @param command [String] The command to interact with
   # @param stdin [Array<Regex, String>] List of pairs [regex, string] to print as stdin
   # @return [Boolean] <= 0 is true, anything else is false
-  def tpm_takeownership(expect_array, cmd = '/sbin/tpm_takeownership' )
+  def tpm_takeownership(expect_array, cmd = 'tpm_takeownership' )
     require 'expect'
     require 'pty'
 
@@ -53,11 +53,6 @@ Puppet::Type.type(:tpm_ownership).provide :trousers do
       expect_array.each do |reg,stdin|
         begin
           r.expect( reg, pty_timeout) do |s|
-            # if s.nil?
-            #   err('tpm_takeownership command timed out, killing process')
-            #   Process.kill(9, pid)
-            #   return false
-            # end
             w.puts stdin
             debug( [reg, stdin, s] )
           end

--- a/lib/puppet/type/tpm_ownership.rb
+++ b/lib/puppet/type/tpm_ownership.rb
@@ -15,7 +15,9 @@
 require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:tpm_ownership) do
-  @doc = "A type to manage ownership of a TPM. `owner_pass` and `srk_pass` are required.
+  @doc = "A type to manage ownership of a TPM. `owner_pass` is required, while `srk_pass`
+is only required if you aren't using Trusted Boot or the PKCS#11 interface. The
+SRK password is required to be null in order to sue those features.
 
 Example:
 
@@ -24,7 +26,6 @@ Example:
   tpm_ownership { 'tpm0':
     ensure     => present,
     owner_pass => 'badpass',
-    srk_pass   => 'badpass2'
   }
 "
 
@@ -48,12 +49,13 @@ Example:
   end
 
   newparam(:srk_pass) do
-    desc 'The SRK password of the TPM'
+    desc 'The Storage Root Key(SRK) password of the TPM'
     validate do |value|
       unless value.is_a?(String)
         raise(Puppet::Error, "$owner_pass must be a String, not '#{value.class}'")
       end
     end
+    defaultto '' # Empty string
   end
 
   newparam(:name, :namevar => true) do
@@ -76,8 +78,8 @@ Example:
   end
 
   validate do
-    if self[:owner_pass].nil? or self[:srk_pass].nil?
-      fail('Both passwords are required to use this type')
+    if self[:owner_pass].nil?
+      fail('Owner password is required to use this type')
     end
   end
 

--- a/manifests/ownership.pp
+++ b/manifests/ownership.pp
@@ -7,7 +7,9 @@
 #
 # @param owner_pass [String] The TPM owner password
 #
-# @param srk_pass [String] The TPM SRK password
+# @param srk_pass [String] The TPM SRK password. This is defaulted to an empty
+#   because according to the [trousers documentation](http://trousers.sourceforge.net/pkcs11.html)
+#   it needs to be null to be useful.
 #
 # @param advanced_facts [Boolean] This option will enable facts that require
 #   the owner password to function. The password will be on the client
@@ -17,7 +19,7 @@
 #
 class tpm::ownership (
   $owner_pass     = passgen( "${::fqdn}_tpm0_owner_pass", { 'length' => 20 } ),
-  $srk_pass       = passgen( "${::fqdn}_tpm0_srk_pass", { 'length' => 20 } ),
+  $srk_pass       = '',
   $advanced_facts = false
 ){
   validate_bool($advanced_facts)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-tpm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author":  "simp",
   "summary": "manages TPMs and IMA (if your system supports it)",
   "license": "Apache-2.0",

--- a/spec/unit/puppet/type/tpm_ownership_spec.rb
+++ b/spec/unit/puppet/type/tpm_ownership_spec.rb
@@ -42,17 +42,15 @@ describe Puppet::Type.type(:tpm_ownership) do
     end
   end
 
-  [:owner_pass, :srk_pass].each do |param|
-    it "should fail to run with only the #{param} field" do
-      # skip("TODO: Figure out how to require the #{param} parameter")
-      expect {
-       Puppet::Type.type(:tpm_ownership).new(
-         :name => 'tpm0',
-         param => 'badpass'
-       )
-     }.to raise_error(Puppet::ResourceError)
-    end
+  it 'should fail to run without the owner_pass field' do
+    expect {
+      Puppet::Type.type(:tpm_ownership).new(
+        :name => 'tpm0',
+      )
+    }.to raise_error(Puppet::ResourceError)
+  end
 
+  [:owner_pass, :srk_pass].each do |param|
     it 'should require a string for both passwords' do
       expect {
         Puppet::Type.type(:tpm_ownership).new(


### PR DESCRIPTION
Make the default SRK password to null for PKCS#11[1](http://trousers.sourceforge.net/pkcs11.html) and Trusted Boot
reasons.

Removed the clean_text funstion from the tpm fact because it all works
now?

Also changed the tpm_takeownership executable to work in both CentOS 6
and 7.

SIMP-1518 #close
