### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,3 +1,9 @@
-Requires: pupmod-herculesteam-augeasproviders >= 1.0.2-1
-Requires: pupmod-simp-compliance_markup
 Obsoletes: pupmod-tpm-test >= 0.0.1
+Requires: pupmod-herculesteam-augeasproviders < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders >= 2.1.3-0
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,28 +1,34 @@
 {
-  "name":    "simp-tpm",
+  "name": "simp-tpm",
   "version": "0.2.0",
-  "author":  "simp",
+  "author": "simp",
   "summary": "manages TPMs and IMA (if your system supports it)",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-tpm",
+  "source": "https://github.com/simp/pupmod-simp-tpm",
   "project_page": "https://github.com/simp/pupmod-simp-tpm",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "tpm", "ima", "pkcs11" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "tpm",
+    "ima",
+    "pkcs11"
+  ],
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders",
-      "version_requirement": ">= 1.0.2"
+      "version_requirement": ">= 2.1.3 < 3.0.0"
     },
-    {  "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+    {
+      "name": "simp/simplib",
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-tpm`
SIMP-1602 #close