### PR TITLE
(SIMP-1484) Expose TPM PKCS#11 interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Tue Sep 27 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.2.0-0
+* Fri Sep 30 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.2.0-0
+- Added a feature to manage the PKCS#11 slot provided by the TPM
+- Also added a class that takes advantage of it
+
+* Tue Sep 27 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0-0
 - Added functionality to take ownership of the TPM
 
 * Tue Mar 01 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 0.0.1-10

--- a/README.md
+++ b/README.md
@@ -118,15 +118,27 @@ tpm::ownership::owner_pass: 'badpass'
 tpm::ownership::srk_pass: ''
 ```
 
-To enable IMA, add this line to hiera:
+To enable IMA and the PKCS #11 interface, add this to hiera:
 
 ```yaml
 tpm::use_ima: true
+tpm::enable_pkcs_interface: true
 ```
+
+To enable the PKCS#11 interface, add the `tpm::pkcs11` class to your node and set the PINs in hiera:
+
+```yaml
+classes:
+  - tpm::pkcs11
+
+tpm::pkcs11::so_pin: '12345678'
+tpm::pkcs11::user_pin: '87654321'
+```
+
 
 ## Usage
 
-The type and provider provided in this module can be used as follows:
+The type and provider for tpm ownership provided in this module can be used as follows:
 
 ```puppet
 tpm_ownership { 'tpm0':
@@ -134,6 +146,16 @@ tpm_ownership { 'tpm0':
   owner_pass     => 'badpass',
   srk_pass       => 'badpass2',
   advanced_facts => true
+}
+```
+
+And the PKCS#11 slot type and provider can be used as follows:
+
+```puppet
+tpmtoken { 'TPM PKCS#11 token':
+  ensure   => present,
+  so_pin   => '12345678',
+  user_pin => '87654321'
 }
 ```
 

--- a/lib/puppet/provider/tpmtoken/pkcsconf.rb
+++ b/lib/puppet/provider/tpmtoken/pkcsconf.rb
@@ -1,0 +1,163 @@
+#
+# @author Nick Miller <nick.miller@onyxpoint.com>
+#
+Puppet::Type.type(:tpmtoken).provide :pkcsconf do
+
+  confine :has_tpm => true
+
+  defaultfor :kernel => :Linux
+
+  commands :pkcsconf        => 'pkcsconf'
+  commands :tpmtoken_init   => 'tpmtoken_init'
+  commands :tpm_restrictsrk => 'tpm_restrictsrk'
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def tpmtoken_init(expect_array, cmd = 'tpmtoken_init')
+    require 'expect'
+    require 'pty'
+
+    pty_timeout = 15
+
+    PTY.spawn( cmd ) do |r,w,pid|
+      w.sync = true
+
+      expect_array.each do |reg,stdin|
+        debug("Starting the expect session with #{cmd}")
+        begin
+          r.expect( reg, pty_timeout) do |s|
+            w.puts stdin
+            debug( "Matched: #{s} | Matcher regex: #{reg} | String typed in: #{stdin}" )
+          end
+        rescue Errno::EIO
+        end
+      end
+
+      Process.wait(pid) # set $? to the correct exit code
+    end
+    exit_code = $?
+    debug( "exit code #{exit_code}" )
+
+    if exit_code.exitstatus == 0
+      return true
+    else
+      return false
+    end
+
+  end
+
+  def initialize_token(so_pin, user_pin)
+    stdin = [
+      [ /Enter new password:/i, so_pin   ],
+      [ /Confirm password/i,    so_pin   ],
+      [ /Enter new password:/i, user_pin ],
+      [ /Confirm password/i,    user_pin ],
+    ]
+    success = tpmtoken_init(stdin)
+    debug("Ran tpmtoken_init, which returned exit code: #{success}")
+    err('Ininitalizing the TPM PKCS#11 token failed') unless success
+  end
+
+  # @return [Array<Hash>] returns an array of hashes, with each hash
+  #   representing a different PKCS#11 token
+  def self.read_tokens
+    require 'yaml'
+
+    begin
+      cmd = pkcsconf(['-t']).split("\n")
+      debug("Ran pkcsconf -t, with output: #{cmd}")
+    rescue Puppet::ExecutionFailure => e
+      Puppet.debug "#read_slots had an error -> #{e.inspect}"
+      return []
+    end
+
+    # clean the output so the YAML parser will read it
+    cmd.each do |line|
+      line.gsub!(/\t/,' '*4)        # tabs make YAML unhappy
+      line.gsub!(/[^[:print:]]/,'') # removes non-printable characters, like \b
+      line.gsub!(/#/,'')            # the hash symbol also makes YAML misbehave
+    end
+    debug('Cleaned the text, now loading YAML')
+    y = YAML.load(cmd.join("\n"))
+
+    # lowercase all the keys and replace all spaces with _
+    lower = []
+    y.values.each do |val|
+      debug('Lowercasing all the keys')
+      lower << Hash[val.map{ |k,v| [k.downcase.gsub(/ /, '_').to_sym, v] }]
+    end
+
+    properties = []
+    lower.each do |prop|
+      # isolate the flags
+      prop[:flags_raw] = prop[:flags]
+      prop[:flags]     = prop[:flags_raw].scan(/([A-Z_]{3,})/ ).flatten
+
+      # these need to be in the type
+      prop[:name]   = prop[:label]
+      prop[:ensure] = prop[:flags].include?('TOKEN_INITIALIZED') ? :present : :absent
+
+      debug("Found token: #{prop.to_json}")
+      properties << prop
+    end
+
+    properties
+  end
+
+  def self.instances
+    list = []
+    read_tokens.each do |token|
+      debug("Adding instance of '#{token[:label]}'")
+      list << new(token)
+    end
+    list
+  end
+
+  def self.prefetch(resources)
+    debug('Prefetching')
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      f = File.expand_path('/var/lib/opencryptoki/tpm/root')
+      FileUtils.rm_rf(f) if File.exists?(f)
+      debug("Deleted interface #{resource[:name]} folder at #{f}")
+      @property_hash[:ensure] = :absent
+    end
+
+    if @property_flush[:ensure] == :present
+      if resource[:so_pin].nil? or resource[:user_pin].nil?
+        raise(Puppet::Error, 'Both PINs are required to use pkcs_slot')
+      end
+      debug('Initializing token using initialize_token')
+      initialize_token( resource[:so_pin], resource[:user_pin] )
+      @property_hash[:ensure] = :present
+    end
+  end
+
+  def exists?
+    debug('Checking if resource exists')
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    debug('Creating resource')
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    debug('Destroying resource')
+    @property_flush[:ensure] = :absent
+  end
+
+end

--- a/lib/puppet/type/tpmtoken.rb
+++ b/lib/puppet/type/tpmtoken.rb
@@ -1,0 +1,54 @@
+# Ininitalize and manage certs in the TPM PKCS #11 interface
+#
+# @author Nick Miller <nick.miller@onyxpoint.com>
+#
+Puppet::Type.newtype(:tpmtoken) do
+  @doc = "THis type will manage the PKCS #11 interface provided by opencryptoki,
+and backed my the TPM.
+
+Example:
+  include 'tpm'
+
+  tpmtoken { 'tpmtok':
+    ensure   => present,
+    so_pin   => '87654321',
+    user_pin => '87654321'
+  }"
+
+  ensurable
+
+  newparam(:label, :namevar => true) do
+    desc 'The tag of the slot, to be used during initialization'
+  end
+
+  # newparam(:slot) do
+  #   desc 'The slot in the PKCS #11 interface you would like to manage'
+  #   defaultto 0
+  # end
+
+  newparam(:so_pin) do
+    desc 'Security Officer (SO) PIN for the interface'
+    validate do |value|
+      if value.length < 4 or value.length > 8
+        fail("Pin needs to be between 4 and 8 characters")
+      end
+    end
+  end
+
+  newparam(:user_pin) do
+    desc 'User PIN for the interface'
+    validate do |value|
+      if value.length < 4 or value.length > 8
+        fail("Pin needs to be between 4 and 8 characters")
+      end
+    end
+  end
+
+  autorequire(:package) do
+    [ 'opencryptoki','opencryptoki-tpmtok','tpm-tools-pkcs11' ]
+  end
+  autorequire(:service) do
+    'pkcsslotd'
+  end
+
+end

--- a/manifests/pkcs11.pp
+++ b/manifests/pkcs11.pp
@@ -1,0 +1,34 @@
+# Manage the tpm-enabled PKCS #11 interface
+#
+# If the SO_PIN_LOCKED flag gets thrown, you will have to reset your interface
+#   by deleting the /var/lib/opencryptoki/tpm/root/NVTOK.DAT file.
+#
+# @param so_pin [String] 4-8 character password used for the Security Officer pin.
+#
+# @param user_pin [String] 4-8 character password used for the user pin.
+#
+class tpm::pkcs11 (
+  $so_pin   = passgen( "${::fqdn}_pkcs_so_pin", { 'length' => 8 } ),
+  $user_pin = passgen( "${::fqdn}_pkcs_user_pin", { 'length' => 8 } ),
+){
+  ##################################################################################################################
+  # Here's a nice doc on how to set up the PKCS #11 interface
+  # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html
+  # http://trousers.sourceforge.net/pkcs11.html
+  ##################################################################################################################
+  package { 'opencryptoki': ensure => latest }
+  package { 'opencryptoki-tpmtok': ensure => latest }
+  package { 'tpm-tools-pkcs11': ensure => latest }
+
+  service { 'pkcsslotd':
+    ensure => running,
+    enable => true,
+  }
+
+  tpmtoken { 'TPM PKCS#11 Token':
+    ensure   => present,
+    so_pin   => '87654321',
+    user_pin => '87654321'
+  }
+
+}

--- a/spec/classes/pkcs11_spec.rb
+++ b/spec/classes/pkcs11_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'tpm::pkcs11' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+
+      it { is_expected.to create_class('tpm::pkcs11') }
+      it { is_expected.to create_package('opencryptoki') }
+      it { is_expected.to create_package('opencryptoki-tpmtok') }
+      it { is_expected.to create_package('tpm-tools-pkcs11') }
+      it { is_expected.to create_service('pkcsslotd').with({
+        :ensure => 'running',
+        :enable => true
+      }) }
+
+    end
+  end
+
+end

--- a/spec/files/mock_tpmtoken_init.rb
+++ b/spec/files/mock_tpmtoken_init.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+def tpmtoken_init
+  system "stty -echo"
+
+  puts 'A new TPM security officer password is needed. The password must be between 4 and 8 characters in length.'
+  print 'Enter new password: '
+  owner_pass = gets.chomp
+  print "\nConfirm password: "
+  owner_pass_confirm = gets.chomp
+
+  if !owner_pass.eql? owner_pass_confirm
+    puts "\nPasswords didn't match"
+    return 1
+  else
+    puts
+  end
+
+  sleep 2
+
+  puts 'A new TPM user password is needed. The password must be between 4 and 8 characters in length.'
+  print 'Enter new password: '
+  srk_pass = gets.chomp
+  print "\nConfirm password: "
+  srk_pass_confirm = gets.chomp
+
+  if !srk_pass.eql? srk_pass_confirm
+    puts "\nPasswords didn't match"
+    return 1
+  end
+
+  sleep 2
+
+  system "stty echo"
+  puts
+  return 0
+end
+
+if ENV['MOCK_TIMEOUT'] == 'yes'
+  sleep 30
+  tpmtoken_init
+else
+  tpmtoken_init
+end

--- a/spec/files/pkcsconf_t.out
+++ b/spec/files/pkcsconf_t.out
@@ -1,0 +1,28 @@
+Token #0 Info:
+	Label: IBM PKCS#11 TPM Token
+	Manufacturer: IBM Corp.
+	Model: TPM v1.1 Token
+	Serial Number: 123
+	Flags: 0x44D (RNG|LOGIN_REQUIRED|USER_PIN_INITIALIZED|CLOCK_ON_TOKEN|TOKEN_INITIALIZED)
+	Sessions: 0/-2
+	R/W Sessions: -1/-2
+	PIN Length: 4-8
+	Public Memory: 0xFFFFFFFF/0xFFFFFFFF
+	Private Memory: 0xFFFFFFFF/0xFFFFFFFF
+	Hardware Version: 1.0
+	Firmware Version: 1.0
+	Time: 18:33:07
+Token #1 Info:
+	Label: IBM PKCS#11 TPM Token
+	Manufacturer: Test Corp.
+	Model: TPM v1.1 Token
+	Serial Number: 123
+	Flags: 0x44D (RNG|LOGIN_REQUIRED|USER_PIN_INITIALIZED|CLOCK_ON_TOKEN|TOKEN_INITIALIZED)
+	Sessions: 0/-2
+	R/W Sessions: -1/-2
+	PIN Length: 4-8
+	Public Memory: 0xFFFFFFFF/0xFFFFFFFF
+	Private Memory: 0xFFFFFFFF/0xFFFFFFFF
+	Hardware Version: 1.0
+	Firmware Version: 1.0
+	Time: 18:33:07

--- a/spec/files/pkcsconf_t_hash.json
+++ b/spec/files/pkcsconf_t_hash.json
@@ -1,0 +1,38 @@
+[
+  {
+    "label": "IBM PKCS11 TPM Token",
+    "manufacturer": "IBM Corp.",
+    "model": "TPM v1.1 Token",
+    "serial_number": 123,
+    "flags": ["RNG", "LOGIN_REQUIRED", "USER_PIN_INITIALIZED", "CLOCK_ON_TOKEN", "TOKEN_INITIALIZED"],
+    "sessions": "0/-2",
+    "r/w_sessions": "-1/-2",
+    "pin_length": "4-8",
+    "public_memory": "0xFFFFFFFF/0xFFFFFFFF",
+    "private_memory": "0xFFFFFFFF/0xFFFFFFFF",
+    "hardware_version": 1.0,
+    "firmware_version": 1.0,
+    "time": 66787,
+    "flags_raw": "0x44D (RNG|LOGIN_REQUIRED|USER_PIN_INITIALIZED|CLOCK_ON_TOKEN|TOKEN_INITIALIZED)",
+    "name": "IBM PKCS11 TPM Token",
+    "ensure": "present"
+  },
+  {
+    "label": "IBM PKCS11 TPM Token",
+    "manufacturer": "Test Corp.",
+    "model": "TPM v1.1 Token",
+    "serial_number": 123,
+    "flags": ["RNG", "LOGIN_REQUIRED", "USER_PIN_INITIALIZED", "CLOCK_ON_TOKEN", "TOKEN_INITIALIZED"],
+    "sessions": "0/-2",
+    "r/w_sessions": "-1/-2",
+    "pin_length": "4-8",
+    "public_memory": "0xFFFFFFFF/0xFFFFFFFF",
+    "private_memory": "0xFFFFFFFF/0xFFFFFFFF",
+    "hardware_version": 1.0,
+    "firmware_version": 1.0,
+    "time": 66787,
+    "flags_raw": "0x44D (RNG|LOGIN_REQUIRED|USER_PIN_INITIALIZED|CLOCK_ON_TOKEN|TOKEN_INITIALIZED)",
+    "name": "IBM PKCS11 TPM Token",
+    "ensure": "present"
+  }
+]

--- a/spec/unit/facter/pkcs_slots_spec.rb
+++ b/spec/unit/facter/pkcs_slots_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'pkcs_slots', :type => :fact do
+
+  before :each do
+    Facter.clear
+    Facter.clear_messages
+  end
+
+  it 'is not tested yet' do
+    skip('test this?')
+  end
+
+end

--- a/spec/unit/puppet/provider/tpmtoken/pkcsconf_spec.rb
+++ b/spec/unit/puppet/provider/tpmtoken/pkcsconf_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+require 'json'
+
+describe Puppet::Type.type(:tpmtoken).provider(:pkcsconf) do
+
+  let(:resource) {
+    Puppet::Type.type(:tpmtoken).new({
+      :name     => 'IBM PKCS11 TPM Token',
+      :so_pin   => '123456',
+      :user_pin => '12345678',
+      :provider => 'pkcsconf'
+    })
+  }
+  let(:provider) { resource.provider }
+
+  let(:pkcsconf_t_out) {
+    File.read(File.expand_path('spec/files/pkcsconf_t.out'))
+  }
+  let(:pkcsconf_t_hash) {
+    j = JSON.parse(
+      File.read(File.expand_path('spec/files/pkcsconf_t_hash.json')),
+      :symbolize_names => true
+    )
+
+    j.each do |r|
+      r.map do |k,v|
+        r.merge!( { k => v.to_sym } ) if v.eql? "present"
+      end
+    end
+  }
+
+  before(:each) do
+    provider.stubs(:pkcsconf).with(['-t']).returns(pkcsconf_t_out)
+    provider.class.stubs(:pkcsconf).with(['-t']).returns(pkcsconf_t_out)
+    provider.stubs(:new).returns(pkcsconf_t_hash[0], pkcsconf_t_hash[1])
+  end
+
+  after :each do
+    ENV['MOCK_TIMEOUT'] =  nil
+  end
+
+  # context 'default' do
+  #   let(:resource) {
+  #     Puppet::Type.type(:pkcs_slot).new({
+  #       :name    => 'IBM PKCS11 TPM Token',
+  #       :so_pin   => '123456',
+  #       :user_pin => '12345678',
+  #       :provider => 'pkcsconf'
+  #     })
+  #   }
+  #
+  # end
+
+  describe 'instances' do
+    it 'should take output from pkcsconf -t and turn it into a hash' do
+      expect(provider.class.read_tokens).to eql(pkcsconf_t_hash)
+    end
+  end
+
+  describe 'tpmtoken_init' do
+    let(:stdin) {[
+      [ /Enter new password:/i, resource[:so_pin]   ],
+      [ /Confirm password/i,    resource[:so_pin]   ],
+      [ /Enter new password:/i, resource[:user_pin] ],
+      [ /Confirm password/i,    resource[:user_pin] ],
+    ]}
+    let(:mock_script) { File.expand_path('spec/files/mock_tpmtoken_init.rb') }
+
+    it 'should interact with the script normally' do
+      expect(provider.tpmtoken_init( stdin, mock_script )).to be_truthy
+    end
+
+    # it 'should interact with the script normally' do
+    #   ENV['MOCK_TIMEOUT'] = 'yes'
+    #   expect(provider.tpmtoken_init( stdin, mock_script )).to be_falsey
+    # end
+
+  end
+
+end

--- a/spec/unit/puppet/type/tpmtoken_spec.rb
+++ b/spec/unit/puppet/type/tpmtoken_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:tpmtoken) do
+
+  [:so_pin, :user_pin].each do |param|
+
+    it "should accept #{param} with 8 characters" do
+      expect {
+        Puppet::Type.type(:tpmtoken).new(
+          :name => 'IBM PKCS11 TPM Token',
+          param => '1234'
+        )
+      }.not_to raise_error
+    end
+
+    it "should accept #{param} with 4 characters" do
+      expect {
+        Puppet::Type.type(:tpmtoken).new(
+          :name => 'IBM PKCS11 TPM Token',
+          param => '12345678'
+        )
+      }.not_to raise_error
+    end
+
+    it "should fail #{param} with less than 4 characters" do
+      expect {
+        Puppet::Type.type(:tpmtoken).new(
+          :name => 'IBM PKCS11 TPM Token',
+          param => '123'
+        )
+      }.to raise_error(Puppet::ResourceError)
+    end
+
+    it "should fail #{param} with more than 8 characters" do
+      expect {
+        Puppet::Type.type(:tpmtoken).new(
+          :name => 'IBM PKCS11 TPM Token',
+          param => '123456789'
+        )
+      }.to raise_error(Puppet::ResourceError)
+    end
+  end
+
+end


### PR DESCRIPTION
This commit introduces a type and provider that will expose and
eventually amke use of the PKCS#11 interface on the TPM. It has a fact
with that status of the interface, using `pkcsconf`, and a provider that
uses `tpmtoken_init` to initialize the interface and change the SO pin
and the user pin.

The provider supports using `puppet resource`.

SIMP-1484 #close