### PR TITLE
(SIMP-1450) Update Requires

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -5,5 +5,5 @@ Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
 Requires: pupmod-simp-compliance_markup < 2.0.0-0
 Requires: pupmod-simp-compliance_markup >= 1.0.1-0
-Requires: pupmod-simp-simplib < 2.0.0-0
-Requires: pupmod-simp-simplib >= 1.3.1-0
+Requires: pupmod-simp-simplib >= 2.0.0-0
+Requires: pupmod-simp-simplib < 3.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.3.1 < 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
```
update requires and metadata to use new versions
of simp modules for SIMP 6.
```

SIMP-1450 #close
