### PR TITLE
(SIMP-2044) Check securityfs in ima_log_size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Nov 17 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.2.1-0
+- Added a check to the ima_log_size fact to make sure that the file
+  needed exists before executing
+
 * Tue Sep 27 2016 Nick Miller <nick.miller@onyxpoint.com> - 0.2.0-0
 - Added functionality to take ownership of the TPM
 

--- a/lib/facter/ima_log_size.rb
+++ b/lib/facter/ima_log_size.rb
@@ -1,5 +1,7 @@
 # Detects the size if the IMA log in bytes
 Facter.add('ima_log_size') do
+  confine :exists => '/sys/kernel/security/ima/ascii_runtime_measurements'
+
   setcode do
     Facter::Core::Execution.execute('wc -c /sys/kernel/security/ima/ascii_runtime_measurements').to_i
   end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tpm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "simp",
   "summary": "manages TPMs and IMA (if your system supports it)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Add a check to the ima_log_size fact to make sure securityfs and the
file needed exists before checking the size of it

SIMP-2044 #close