### PR TITLE
(SIMP-3596) Lock kernel version when using tboot

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,12 @@
 ---
 fixtures:
   repositories:
-    augeasproviders_core:
-      repo: https://github.com/simp/augeasproviders_core
-      branch: simp-master
-    augeasproviders_grub:
-      repo: https://github.com/simp/augeasproviders_grub
-      branch: simp-master
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
+    concat: https://github.com/simp/puppetlabs-concat
     rsync: https://github.com/simp/pupmod-simp-rsync
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    yum: https://github.com/simp/puppet-yum
   symlinks:
     tpm: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - STRICT_VARIABLES=yes
   matrix:
     - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 5.0.1"
+    - PUPPET_VERSION="~> 5.0"
     - PUPPET_VERSION="~> 4.10.0"
     - PUPPET_VERSION="~> 4.9.2"
     - PUPPET_VERSION="~> 4.7.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Mon Aug 07 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.0-0
 - Added tboot support. See tpm::tboot for details
 - Added documentation for providers to make puppet strings happy
+- Added a version lock for the kernel and kernel related packages to avoid
+  automatically invalidating your launch policy
 
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ classes:
 8. Reboot into the normal tboot boot option
 9. Check the `tboot` fact for a measured launch: `puppet facts | grep measured_launch` or just run `txt-stat`
 
+#### Locking the kernel
+
+The `tpm::tboot` class will use the `yum::versionlock` define from the
+`voxpupuli/yum` module to make sure the version of the kernel that the tboot
+policy was created with doesn't get upgraded without the user knowing. To
+disable this, set the `tpm::tboot::lock_kernel_packages` parameter to `false`.
+
+This module does provide a script to upgrade the policy, though it shouldn't be
+run from Puppet. To update your verified launch policy, do the following steps:
+
+1. `yum update kernel`
+2. `grub2-mkconfig -o /etc/grub2.cfg`
+3. `sh /root/txt/txt/update_tboot_policy.sh <owner password>`
+
+And reboot!
+
 ## Reference
 
 Please refer to the inline documentation within each source file, or to the module's generated YARD documentation for reference material.

--- a/files/create_lcp_tboot_policy.sh
+++ b/files/create_lcp_tboot_policy.sh
@@ -37,7 +37,7 @@ fi
 if [[ -f /etc/default/grub-tboot ]]; then
     source /etc/default/grub-tboot
 else
-    GRUB_CMDLINE_TBOOT="logging=serial,memory,vga"
+    GRUB_CMDLINE_TBOOT="logging=serial,memory,vga min_ram=0x2000000"
 fi
 
 # Clean up the files after we're done?

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -21,6 +21,8 @@
 class tpm::tboot (
   Boolean              $intermediate_grub_entry = true,
   Boolean              $purge_boot_entries      = false,
+  Boolean              $lock_kernel_packages    = true,
+  Array[String]        $kernel_packages_to_lock = ['kernel','kernel-bigmem','kernel-enterprise', 'kernel-smp','kernel-debug','kernel-unsupported','kernel-source','kernel-devel','kernel-PAE','kernel-PAE-debug','kernel-modules'],
   Optional[String]     $sinit_name              = undef,
   Optional[String]     $sinit_source            = simplib::lookup('simp_options::rsync', { 'default_value' => undef }),
   String               $rsync_source            = "tboot_${::environment}/",
@@ -44,6 +46,7 @@ class tpm::tboot (
   include 'tpm::tboot::sinit'
   include 'tpm::tboot::policy'
   include 'tpm::tboot::grub'
+  include 'tpm::tboot::lock_kernel'
 
   Class['tpm']
   -> Class['tpm::tboot::sinit']

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -38,6 +38,8 @@ class tpm::tboot (
   Array[String]        $additional_boot_options = ['intel_iommu=on'],
   Stdlib::AbsolutePath $policy_script           = '/root/txt/create_lcp_boot_policy.sh',
   String               $policy_script_source    = 'puppet:///modules/tpm/create_lcp_tboot_policy.sh',
+  Stdlib::AbsolutePath $update_script           = '/root/txt/update_tboot_policy.sh',
+  String               $update_script_source    = 'puppet:///modules/tpm/update_tboot_policy.sh',
   String               $package_ensure          = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
   include 'tpm'

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -2,6 +2,8 @@
 #
 # @param intermediate_grub_entry Provide a tboot Grub entry with no policy, for bootstrapping
 # @param purge_boot_entries Remove other, nontrusted boot entries from Grub
+# @param lock_kernel_packages Lock kernel related packages in YUM, to avoid accidentally invalidating the launch policy
+# @param kernel_packages_to_lock List of kernel related packages to lock
 # @param sinit_name Name of the SINIT policy file, usually ending in `*.BIN`
 # @param sinit_source Puppet `file` resouce source arrtibute for the SINIT binary
 #   @example The binary was manually copied over to `/root/BIN`, so this entry was set to `file:///root/BIN`
@@ -22,7 +24,10 @@ class tpm::tboot (
   Boolean              $intermediate_grub_entry = true,
   Boolean              $purge_boot_entries      = false,
   Boolean              $lock_kernel_packages    = true,
-  Array[String]        $kernel_packages_to_lock = ['kernel','kernel-bigmem','kernel-enterprise', 'kernel-smp','kernel-debug','kernel-unsupported','kernel-source','kernel-devel','kernel-PAE','kernel-PAE-debug','kernel-modules'],
+  Array[String]        $kernel_packages_to_lock = [ 'kernel','kernel-bigmem','kernel-enterprise',
+                                                    'kernel-smp','kernel-debug','kernel-unsupported',
+                                                    'kernel-source','kernel-devel','kernel-PAE',
+                                                    'kernel-PAE-debug','kernel-modules' ],
   Optional[String]     $sinit_name              = undef,
   Optional[String]     $sinit_source            = simplib::lookup('simp_options::rsync', { 'default_value' => undef }),
   String               $rsync_source            = "tboot_${::environment}/",
@@ -37,11 +42,17 @@ class tpm::tboot (
 ) {
   include 'tpm'
 
-  reboot_notify { 'Launch tboot': reason => 'tboot policy has been written, please reboot to complete a verified launch' }
+  reboot_notify { 'Launch tboot':
+    reason => 'tboot policy has been written, please reboot to complete a verified launch'
+  }
 
-  file { '/root/txt/': ensure => directory }
+  file { '/root/txt/':
+    ensure => directory
+  }
 
-  package { 'tboot': ensure => $package_ensure }
+  package { 'tboot':
+    ensure => $package_ensure
+  }
 
   include 'tpm::tboot::sinit'
   include 'tpm::tboot::policy'

--- a/manifests/tboot/grub.pp
+++ b/manifests/tboot/grub.pp
@@ -2,6 +2,7 @@
 # This class is controlled by `tpm::tboot`
 #
 class tpm::tboot::grub {
+  assert_private()
 
   $sinit_name    = $tpm::tboot::sinit_name
 

--- a/manifests/tboot/lock_kernel.pp
+++ b/manifests/tboot/lock_kernel.pp
@@ -1,5 +1,8 @@
+# Lock the kernel to avoid automatically invalidating the launch policy
+# This class is controlled by `tpm::tboot`
 #
 class tpm::tboot::lock_kernel {
+  assert_private()
 
   $lock_kernel_packages    = $tpm::tboot::lock_kernel_packages
   $kernel_packages_to_lock = $tpm::tboot::kernel_packages_to_lock

--- a/manifests/tboot/lock_kernel.pp
+++ b/manifests/tboot/lock_kernel.pp
@@ -1,0 +1,17 @@
+#
+class tpm::tboot::lock_kernel {
+
+  $lock_kernel_packages    = $tpm::tboot::lock_kernel_packages
+  $kernel_packages_to_lock = $tpm::tboot::kernel_packages_to_lock
+
+  $kernel_packages_to_lock.each |$kernel_package| {
+    $_ensure = $lock_kernel_packages ? {
+      true    => present,
+      default => absent
+    }
+    yum::versionlock { "*:${kernel_package}-*-*.*":
+      ensure => $_ensure
+    }
+  }
+
+}

--- a/manifests/tboot/policy.pp
+++ b/manifests/tboot/policy.pp
@@ -7,10 +7,17 @@ class tpm::tboot::policy {
   $owner_password       = $tpm::tboot::owner_password
   $policy_script        = $tpm::tboot::policy_script
   $policy_script_source = $tpm::tboot::policy_script_source
+  $update_script        = $tpm::tboot::update_script
+  $update_script_source = $tpm::tboot::update_script_source
 
   file { $policy_script:
     ensure => file,
     source => $policy_script_source
+  }
+
+  file { $update_script:
+    ensure => file,
+    source => $update_script_source
   }
 
   # if the last boot wasn't measured, but we did boot with the tboot kernel

--- a/manifests/tboot/sinit.pp
+++ b/manifests/tboot/sinit.pp
@@ -12,7 +12,9 @@ class tpm::tboot::sinit {
 
   # if the sinit is not built into the bios...
   if $sinit_name {
-    file { '/root/txt/sinit': ensure => directory }
+    file { '/root/txt/sinit':
+      ensure => directory
+    }
 
     if $sinit_source == 'rsync' {
       rsync { 'tboot':

--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0"
+    },
+    {
+      "name": "voxpupuli/yum",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/tboot_spec.rb
+++ b/spec/classes/tboot_spec.rb
@@ -41,6 +41,19 @@ describe 'tpm::tboot' do
             GRUB_TBOOT_POLICY_DATA="list.data"
           EOF
             ) }
+          it 'should lock the default packages' do
+            contain_yum__versionlock('*:kernel-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-bigmem-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-enterprise-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-smp-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-debug-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-unsupported-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-source-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-devel-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-PAE-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-PAE-debug-*-*.*').with_ensure('present')
+            contain_yum__versionlock('*:kernel-modules-*-*.*').with_ensure('present')
+          end
         else
           # it { is_expected.to contain_class('tpm::tboot::grub::grub1') }
           it { is_expected.to compile.and_raise_error(/does not currently support Grub 0.99-1.0/) }
@@ -118,6 +131,22 @@ describe 'tpm::tboot' do
           it { is_expected.not_to contain_exec('Generate and install tboot policy') }
         else
           it { is_expected.to compile.and_raise_error(/does not currently support Grub 0.99-1.0/) }
+        end
+      end
+
+      context 'lock kernel packages => false' do
+        it 'should not lock the default packages' do
+          contain_yum__versionlock('*:kernel-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-bigmem-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-enterprise-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-smp-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-debug-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-unsupported-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-source-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-devel-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-PAE-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-PAE-debug-*-*.*').with_ensure('absent')
+          contain_yum__versionlock('*:kernel-modules-*-*.*').with_ensure('absent')
         end
       end
 


### PR DESCRIPTION
This commit uses voxpupuli/yum to lock the kernel
package and other related packages when using tboot, to avoid
invalidating your launch policy.

SIMP-3596 #close