### PR TITLE
(SIMP-1415) tpm: Add instances feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,21 +1,26 @@
-* Thu Aug 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.1-0
-- add tests for following facts:
-  - tpm
-  - ima_log_size
-  - has_tpm
-- confine tpm fact on the existance of the `tpm-tools` package
-- migrate to the built in facter timeout
-- IMA improvements
-  - Updated the README to be more helpful
-- Lock `kernel-headers` now, as well as the previous kernel packages
+* Thu Aug 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.0-0
+- Improvments to the facts:
+  - Add tests for following facts:
+    - tpm
+    - ima_log_size
+    - has_tpm
+  - Confine tpm fact on the existance of the `tpm-tools` package
+  - Migrate to the built in facter timeout
+- Improvements to the `tpm_ownership` provider
+  - Added instances feature
+    - run `puppet resource tpm_ownership` and see the resource
+  - New properties to the type to reflect system state
+  - Changed default owner_pass to 'well-known'
+  - Removed 'ensure' parameter in favor of the 'owned' param
+  - Improved documentation
+- Improvements to the `tpm::ownership` class
+  - Added 'owned' parameter to pass to the tpm_ownership type
+- New `tpm::tboot` class to enable Trusted Boot
+  - See `tpm::tboot` for details
+  - Automatically lock the kernel package and other kernel related packages to
+    avoid automatically invalidating launch policy
 - Depend on augeasproviders_grub instead of generic and deprecated
   augeasproviders
-
-* Mon Aug 07 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.0-0
-- Added tboot support. See tpm::tboot for details
-- Added documentation for providers to make puppet strings happy
-- Added a version lock for the kernel and kernel related packages to avoid
-  automatically invalidating your launch policy
 
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json

--- a/lib/puppet/provider/tpm_ownership/trousers.rb
+++ b/lib/puppet/provider/tpm_ownership/trousers.rb
@@ -16,8 +16,6 @@ Puppet::Type.type(:tpm_ownership).provide(:trousers) do
 
   commands :tpm_takeownership => 'tpm_takeownership'
 
-  # mk_resource_methods
-
   def initialize(value={})
     super(value)
     @property_flush = {}

--- a/lib/puppet/provider/tpm_ownership/trousers.rb
+++ b/lib/puppet/provider/tpm_ownership/trousers.rb
@@ -1,5 +1,5 @@
 Puppet::Type.type(:tpm_ownership).provide(:trousers) do
-  desc 'The trousers provider for the tpm_ownership type used `tcsd`-provided
+  desc 'The trousers provider for the tpm_ownership type uses `tcsd`-provided
     commands to take ownership of tpm0. Trousers does not allow the user
     to provide a TPM on another path.
 

--- a/lib/puppet/provider/tpm_ownership/trousers.rb
+++ b/lib/puppet/provider/tpm_ownership/trousers.rb
@@ -132,7 +132,7 @@ Puppet::Type.type(:tpm_ownership).provide(:trousers) do
   def owned=(should)
     debug 'Setting property_flush to should'
     if should == :false
-      warning 'This module does not support disowning the tpm'
+      warning 'tpm_ownership does not support disowning the tpm'
       @property_flush[:owned] = :true
     else
       @property_flush[:owned] = should

--- a/lib/puppet/type/tpm_ownership.rb
+++ b/lib/puppet/type/tpm_ownership.rb
@@ -33,14 +33,6 @@ Example:
 
   feature :take_ownership, "The ability to take ownership of a TPM"
 
-  ensurable
-
-  def pre_run_check
-    if !Facter.value(:has_tpm)
-      raise Puppet::Error, "Host doesn't have a TPM"
-    end
-  end
-
   newparam(:owner_pass) do
     desc 'The owner password of the TPM'
     validate do |value|
@@ -57,7 +49,7 @@ Example:
         raise(Puppet::Error, "srk_pass must be a String, not '#{value.class}'")
       end
     end
-    defaultto '' # Empty string
+    defaultto 'well-known'
   end
 
   newparam(:name, :namevar => true) do
@@ -72,17 +64,37 @@ Example:
     defaultto 'false'
   end
 
+
+  newproperty(:owned) do
+    desc 'Ownership status of the TPM'
+    newvalue(:true)
+    newvalue(:false)
+  end
+
+  newproperty(:active) do
+    desc 'Active status of the TPM'
+    newvalue(:true)
+    newvalue(:false)
+  end
+
+  newproperty(:enabled) do
+    desc 'Enabled status of the TPM'
+    newvalue(:true)
+    newvalue(:false)
+  end
+
+  newproperty(:tpm_version) do
+    desc 'Hardware version of the TPM'
+    newvalue(1.2)
+    newvalue(2.0)
+  end
+
+
   autorequire(:package) do
     [ 'trousers','tpm-tools' ]
   end
   autorequire(:service) do
     'tcsd'
-  end
-
-  validate do
-    if self[:owner_pass].nil?
-      fail('Owner password is required to use this type')
-    end
   end
 
 end

--- a/lib/puppet/type/tpm_ownership.rb
+++ b/lib/puppet/type/tpm_ownership.rb
@@ -26,7 +26,7 @@ Example:
   include 'tpm'
 
   tpm_ownership { 'tpm0':
-    ensure     => present,
+    owned      => true,
     owner_pass => 'badpass',
   }
 "
@@ -68,25 +68,7 @@ Example:
 
   newproperty(:owned) do
     desc 'Ownership status of the TPM'
-    newvalues(true,false)
-    def insync?(is)
-      provider.owned
-    end
-  end
-
-  newproperty(:active) do
-    desc 'Active status of the TPM'
-    newvalues(true,false)
-  end
-
-  newproperty(:enabled) do
-    desc 'Enabled status of the TPM'
-    newvalues(true,false)
-  end
-
-  newproperty(:tpm_version) do
-    desc 'Hardware version of the TPM'
-    newvalues(1.2,2.0)
+    newvalues(:true,:false)
   end
 
 

--- a/lib/puppet/type/tpm_ownership.rb
+++ b/lib/puppet/type/tpm_ownership.rb
@@ -33,6 +33,7 @@ Example:
 
   feature :take_ownership, "The ability to take ownership of a TPM"
 
+
   newparam(:owner_pass) do
     desc 'The owner password of the TPM'
     validate do |value|
@@ -67,26 +68,25 @@ Example:
 
   newproperty(:owned) do
     desc 'Ownership status of the TPM'
-    newvalue(:true)
-    newvalue(:false)
+    newvalues(true,false)
+    def insync?(is)
+      provider.owned
+    end
   end
 
   newproperty(:active) do
     desc 'Active status of the TPM'
-    newvalue(:true)
-    newvalue(:false)
+    newvalues(true,false)
   end
 
   newproperty(:enabled) do
     desc 'Enabled status of the TPM'
-    newvalue(:true)
-    newvalue(:false)
+    newvalues(true,false)
   end
 
   newproperty(:tpm_version) do
     desc 'Hardware version of the TPM'
-    newvalue(1.2)
-    newvalue(2.0)
+    newvalues(1.2,2.0)
   end
 
 

--- a/lib/puppet/type/tpmtoken.rb
+++ b/lib/puppet/type/tpmtoken.rb
@@ -1,10 +1,10 @@
-# Ininitalize and manage certs in the TPM PKCS #11 interface
+# Initialize and manage certs in the TPM PKCS #11 interface
 #
 # @author Nick Miller <nick.miller@onyxpoint.com>
 #
 Puppet::Type.newtype(:tpmtoken) do
   @doc = "This type will manage the PKCS #11 interface provided by opencryptoki,
-and backed my the TPM.
+and backed by the TPM.
 
 Example:
   include 'tpm'

--- a/lib/puppet/type/tpmtoken.rb
+++ b/lib/puppet/type/tpmtoken.rb
@@ -3,7 +3,7 @@
 # @author Nick Miller <nick.miller@onyxpoint.com>
 #
 Puppet::Type.newtype(:tpmtoken) do
-  @doc = "THis type will manage the PKCS #11 interface provided by opencryptoki,
+  @doc = "This type will manage the PKCS #11 interface provided by opencryptoki,
 and backed my the TPM.
 
 Example:

--- a/manifests/ownership.pp
+++ b/manifests/ownership.pp
@@ -22,13 +22,13 @@ class tpm::ownership (
   String           $owner_pass     = passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
   Optional[String] $srk_pass       = undef,
   Boolean          $advanced_facts = false
-){
+) {
 
   tpm_ownership { 'tpm0':
     owned          => $owned,
     owner_pass     => $owner_pass,
     srk_pass       => $srk_pass,
-    advanced_facts => $advanced_facts
+    advanced_facts => $advanced_facts,
   }
 
 }

--- a/manifests/ownership.pp
+++ b/manifests/ownership.pp
@@ -18,13 +18,14 @@
 # @author Nick Miller <nick.miller@onyxpoint.com>
 #
 class tpm::ownership (
+  Boolean          $owned          = true,
   String           $owner_pass     = passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
   Optional[String] $srk_pass       = undef,
   Boolean          $advanced_facts = false
 ){
 
   tpm_ownership { 'tpm0':
-    ensure         => present,
+    owned          => $owned,
     owner_pass     => $owner_pass,
     srk_pass       => $srk_pass,
     advanced_facts => $advanced_facts

--- a/spec/classes/ownership_spec.rb
+++ b/spec/classes/ownership_spec.rb
@@ -9,6 +9,7 @@ describe 'tpm::ownership' do
 
       context 'with default parameters and a physical TPM' do
         let(:params) {{
+          'owned'          => true,
           'owner_pass'     => 'badpass1',
           'srk_pass'       => 'badpass2',
           'advanced_facts' => true
@@ -17,7 +18,7 @@ describe 'tpm::ownership' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('tpm::ownership') }
         it { is_expected.to contain_tpm_ownership('tpm0').with({
-          'ensure'         => 'present',
+          'owned'          => true,
           'owner_pass'     => 'badpass1',
           'srk_pass'       => 'badpass2',
           'advanced_facts' => true

--- a/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
+++ b/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
@@ -173,21 +173,4 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
       expect(provider.class.read_sys(mock_sys)).to eq(expected)
     end
   end
-
-  # describe 'exists?' do
-  #   it 'detect TPM is unowned' do
-  #     expect(provider.exists?).to be_falsey
-  #   end
-  # end
-
-  # describe 'create' do
-  #
-  # end
-
-  # describe 'destroy' do
-  #   it 'should log alert and not do anything' do
-  #     expect(provider.destroy).to be_instance_of(Puppet::Util::Log)
-  #   end
-  # end
-
 end

--- a/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
+++ b/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
@@ -23,6 +23,7 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     Puppet.stubs(:[]).with(:vardir).returns('/tmp')
     Facter.stubs(:value).with(:has_tpm).returns(true)
     Facter.stubs(:value).with(:tpm).returns(tpm_fact)
+    FileUtils.stubs(:chown).with('root','root', '/tmp/simp').returns true
   end
 
   after :each do
@@ -173,11 +174,11 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     end
   end
 
-  describe 'exists?' do
-    it 'detect TPM is unowned' do
-      expect(provider.exists?).to be_falsey
-    end
-  end
+  # describe 'exists?' do
+  #   it 'detect TPM is unowned' do
+  #     expect(provider.exists?).to be_falsey
+  #   end
+  # end
 
   # describe 'create' do
   #

--- a/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
+++ b/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
@@ -164,11 +164,8 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     it 'should construct an instances hash from /sys/class/tpm' do
       mock_sys = 'spec/files/tpm/'
       expected = [{
-        :name        => 'tpm',
-        :active      => true,
-        :owned       => true,
-        :enabled     => true,
-        :tpm_version => 1.2,
+        :name  => 'tpm',
+        :owned => :true,
       }]
       expect(provider.class.read_sys(mock_sys)).to eq(expected)
     end

--- a/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
+++ b/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
@@ -6,15 +6,14 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
   let(:provider) { resource.provider }
 
   let(:tpm_fact) {
-    # JSON.load(File.read(File.expand_path('spec/files/tpm_fact.json'), File.dirname(__FILE__)))
     JSON.load(File.read(File.expand_path('spec/files/tpm_fact.json')))
   }
 
   let(:resource) {
     Puppet::Type.type(:tpm_ownership).new({
       :name       => 'tpm0',
-      :owner_pass => 'badpass',
-      :srk_pass   => 'badpass2',
+      :owner_pass => 'twentycharacters0000',
+      :srk_pass   => 'twentycharacters1111',
       :provider   => 'trousers'
     })
   }
@@ -22,18 +21,12 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
 
   before :each do
     Puppet.stubs(:[]).with(:vardir).returns('/tmp')
-
-    FileUtils.stubs(:mkdir).returns(true)
-    FileUtils.stubs(:chown).returns(true)
-
     Facter.stubs(:value).with(:has_tpm).returns(true)
     Facter.stubs(:value).with(:tpm).returns(tpm_fact)
-    # Facter.stubs(:[]).with(:tpm).with(value).returns(tpm_fact)
-    Facter.stubs(:value).with(:kernel).returns(true)
   end
 
   after :each do
-    ENV['MOCK_TIMEOUT'] =  nil
+    ENV['MOCK_TIMEOUT'] = nil
   end
 
 
@@ -41,23 +34,27 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     let(:resource) {
       Puppet::Type.type(:tpm_ownership).new({
         :name            => 'tpm0',
-        :owner_pass      => 'badpass',
-        :srk_pass        => 'badpass2',
+        :owner_pass      => 'twentycharacters0000',
+        :srk_pass        => 'twentycharacters1111',
         :advanced_facts  => true,
         :provider        => 'trousers'
       })
     }
-
-    context 'with advanced_facts => true' do
-      it 'should drop off the password file' do
-        loc = '/tmp'
-        expect(provider.dump_owner_pass(loc)).to match(/badpass/)
-        expect(File.exists?("#{loc}/simp/tpm_ownership_owner_pass")).to be_truthy
-      end
+    let(:loc) { '/tmp' }
+    after :each do
+      file = "#{loc}/simp/tpm_ownership_owner_pass"
+      FileUtils.rm(file) if File.exists? file
     end
+
     context 'with advanced_facts => false' do
       it 'should not do a thing' do
-
+        expect(File.exists?("#{loc}/simp/tpm_ownership_owner_pass")).to be_falsey
+      end
+    end
+    context 'with advanced_facts => true' do
+      it 'should drop off the password file' do
+        expect(provider.dump_owner_pass(loc)).to match(/twentycharacters0000/)
+        expect(File.exists?("#{loc}/simp/tpm_ownership_owner_pass")).to be_truthy
       end
     end
   end
@@ -86,8 +83,8 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
       let(:resource) {
         Puppet::Type.type(:tpm_ownership).new({
           :name       => 'tpm0',
-          :owner_pass => 'badpass',
-          :srk_pass   => 'badpass2',
+          :owner_pass => 'twentycharacters0000',
+          :srk_pass   => 'twentycharacters1111',
           :provider   => 'trousers'
         })
       }
@@ -95,10 +92,10 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
         stdin, cmd = provider.generate_args
 
         expect(stdin).to eq([
-          [ /owner password/i,   'badpass'  ],
-          [ /Confirm password/i, 'badpass'  ],
-          [ /SRK password/i,     'badpass2' ],
-          [ /Confirm password/i, 'badpass2' ],
+          [ /owner password/i,   'twentycharacters0000'  ],
+          [ /Confirm password/i, 'twentycharacters0000'  ],
+          [ /SRK password/i,     'twentycharacters1111' ],
+          [ /Confirm password/i, 'twentycharacters1111' ],
         ])
         expect(cmd).to eq('tpm_takeownership')
       end
@@ -109,7 +106,7 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
         Puppet::Type.type(:tpm_ownership).new({
           :name       => 'tpm0',
           :owner_pass => 'well-known',
-          :srk_pass   => 'badpass2',
+          :srk_pass   => 'twentycharacters1111',
           :provider   => 'trousers'
         })
       }
@@ -117,8 +114,8 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
         stdin, cmd = provider.generate_args
 
         expect(stdin).to eq([
-          [ /SRK password/i,     'badpass2' ],
-          [ /Confirm password/i, 'badpass2' ],
+          [ /SRK password/i,     'twentycharacters1111' ],
+          [ /Confirm password/i, 'twentycharacters1111' ],
         ])
         expect(cmd).to eq('tpm_takeownership -y')
       end
@@ -128,7 +125,7 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
       let(:resource) {
         Puppet::Type.type(:tpm_ownership).new({
           :name       => 'tpm0',
-          :owner_pass => 'badpass',
+          :owner_pass => 'twentycharacters0000',
           :srk_pass   => 'well-known',
           :provider   => 'trousers'
         })
@@ -137,8 +134,8 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
         stdin, cmd = provider.generate_args
 
         expect(stdin).to eq([
-          [ /owner password/i,   'badpass'  ],
-          [ /Confirm password/i, 'badpass'  ],
+          [ /owner password/i,   'twentycharacters0000'  ],
+          [ /Confirm password/i, 'twentycharacters0000'  ],
         ])
         expect(cmd).to eq('tpm_takeownership -z')
       end
@@ -162,6 +159,20 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     end
   end
 
+  describe 'read_sys' do
+    it 'should construct an instances hash from /sys/class/tpm' do
+      mock_sys = 'spec/files/tpm/'
+      expected = [{
+        :name        => 'tpm',
+        :active      => true,
+        :owned       => true,
+        :enabled     => true,
+        :tpm_version => 1.2,
+      }]
+      expect(provider.class.read_sys(mock_sys)).to eq(expected)
+    end
+  end
+
   describe 'exists?' do
     it 'detect TPM is unowned' do
       expect(provider.exists?).to be_falsey
@@ -172,10 +183,10 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
   #
   # end
 
-  describe 'destroy' do
-    it 'should log alert and not do anything' do
-      expect(provider.destroy).to be_instance_of(Puppet::Util::Log)
-    end
-  end
+  # describe 'destroy' do
+  #   it 'should log alert and not do anything' do
+  #     expect(provider.destroy).to be_instance_of(Puppet::Util::Log)
+  #   end
+  # end
 
 end

--- a/spec/unit/puppet/provider/tpmtoken/pkcsconf_spec.rb
+++ b/spec/unit/puppet/provider/tpmtoken/pkcsconf_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Type.type(:tpmtoken).provider(:pkcsconf) do
 
   describe 'instances' do
     it 'should take output from pkcsconf -t and turn it into a hash' do
-      expect(provider.class.read_tokens).to eql(pkcsconf_t_hash)
+      expect(provider.class.read_tokens).to eq(pkcsconf_t_hash)
     end
   end
 

--- a/spec/unit/puppet/type/tpm_ownership_spec.rb
+++ b/spec/unit/puppet/type/tpm_ownership_spec.rb
@@ -6,19 +6,6 @@ describe Puppet::Type.type(:tpm_ownership) do
     Facter.stubs(:value).with(:has_tpm).returns(false)
   end
 
-  context 'pre_run_check' do
-    skip('TODO: figure out how to read this function from rspec')
-    it 'should fail to run on a host without a TPM' do
-      expect {
-        Puppet::Type.type(:tpm_ownership).new(
-          :name           => 'tpm0',
-          :owner_pass     => 'badpass',
-          :srk_pass       => 'badpass',
-        ).pre_run_check
-      }.to raise_error(/Host doesn't have a TPM/)
-    end
-  end
-
   context 'should require a boolean for advanced_facts' do
     it 'is given a boolean' do
       expect {
@@ -40,14 +27,6 @@ describe Puppet::Type.type(:tpm_ownership) do
         )
       }.to raise_error
     end
-  end
-
-  it 'should fail to run without the owner_pass field' do
-    expect {
-      Puppet::Type.type(:tpm_ownership).new(
-        :name => 'tpm0',
-      )
-    }.to raise_error(Puppet::ResourceError)
   end
 
   [:owner_pass, :srk_pass].each do |param|


### PR DESCRIPTION
- Improvements to the tpm_ownership provider
  - Added instances feature
    - run `puppet resource tpm_ownership` and see the resource
  - New properties to the type to reflect system state
  - Changed default owner_pass to 'well-known'
  - Removed 'ensure' parameter in favor of the 'owned' param
- Improvements to the tpm::ownership class
  - Added 'owned' parameter to pass to the tpm_ownership type

SIMP-1415 #close
SIMP-3654 #close
SIMP-3655 #close
SIMP-3656 #close
SIMP-3657 #close