### PR TITLE
(SIMP-3742) ima: Stop policy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
 before_install:
   - rm -f Gemfile.lock
 
-jobs: 
+jobs:
   allow_failures:
     - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 * Mon Dec 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.1-0
 - Updated to support Puppet 5
 - IMA policy service
-  - Moved to systemd unit file from /usr/systemd to /etc/systemd
+  - Moved the import_ima_rules systemd unit file from /usr/systemd to /etc/systemd
+    on systemd based systems
   - Service is now stopped, but enabled, so will only take affect at reboot,
     not during puppet run
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 * Mon Dec 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.1-0
 - Updated to support Puppet 5
-- Moved the IMA policy systemd unit to /etc/systemd
+- IMA policy service
+  - Moved to systemd unit to /etc/systemd
+  - Service is now stopped, but enabled, so will only take affect at reboot,
+    not during puppet run
 
 * Thu Aug 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.0-0
 - Improvments to the facts:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Mon Dec 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.1-0
 - Updated to support Puppet 5
 - IMA policy service
-  - Moved to systemd unit to /etc/systemd
+  - Moved to systemd unit file from /usr/systemd to /etc/systemd
   - Service is now stopped, but enabled, so will only take affect at reboot,
     not during puppet run
 

--- a/manifests/ima/policy.pp
+++ b/manifests/ima/policy.pp
@@ -170,6 +170,8 @@ class tpm::ima::policy (
         source => 'puppet:///modules/tpm/import_ima_rules.service'
       }
       service { 'import_ima_rules.service':
+        # This service is of type one-shot, meaning it isn't able to be running
+        # It is left stopped and enabled to make sure it only runs once at boot
         ensure  => stopped,
         enable  => true,
         require => File['/etc/systemd/system/import_ima_rules.service']
@@ -182,6 +184,8 @@ class tpm::ima::policy (
         source => 'puppet:///modules/tpm/import_ima_rules'
       }
       service { 'import_ima_rules':
+        # This service is of type one-shot, meaning it isn't able to be running
+        # It is left stopped and enabled to make sure it only runs once at boot
         ensure  => stopped,
         enable  => true,
         require => File['/etc/init.d/import_ima_rules']

--- a/manifests/ima/policy.pp
+++ b/manifests/ima/policy.pp
@@ -170,7 +170,7 @@ class tpm::ima::policy (
         source => 'puppet:///modules/tpm/import_ima_rules.service'
       }
       service { 'import_ima_rules.service':
-        ensure  => running,
+        ensure  => stopped,
         enable  => true,
         require => File['/etc/systemd/system/import_ima_rules.service']
       }

--- a/spec/classes/ima/policy_spec.rb
+++ b/spec/classes/ima/policy_spec.rb
@@ -60,7 +60,7 @@ describe 'tpm::ima::policy' do
         else
           it { is_expected.to create_file('/etc/systemd/system/import_ima_rules.service').with_mode('0644') }
           it { is_expected.to create_service('import_ima_rules.service').with.with({
-            :ensure  => 'running',
+            :ensure  => 'stopped',
             :enable  => true,
           }) }
         end


### PR DESCRIPTION
The IMA policy service is now stopped, but enabled, so it will only take
affect at reboot, not during puppet run.

SIMP-3742 #close
SIMP-4096 #close