### PR TITLE
(SIMP-4228) ima: Lighten IMA perms by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jan 03 2017 Nick Miller  <nick.miller@onyxpoint.com> - 1.2.0-0
+- tpm::ima::policy was not previously callable from tpm::ima
+- tpm::ima::policy will now disable many default IMA checks by default
+
 * Mon Dec 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 1.1.1-0
 - Updated to support Puppet 5
 - IMA policy service

--- a/manifests/ima.pp
+++ b/manifests/ima.pp
@@ -62,7 +62,7 @@ class tpm::ima (
       bootmode => 'normal'
     }
     kernel_parameter { 'ima_audit':
-      value    => $ima_audit,
+      value    => bool2str($ima_audit),
       bootmode => 'normal'
     }
     kernel_parameter { 'ima_template':
@@ -86,9 +86,11 @@ class tpm::ima (
       include '::tpm::ima::policy'
     }
 
-    if $facts['ima_log_size'] >= $log_max_size {
-      reboot_notify { 'ima_log':
-        reason => 'The IMA /sys/kernel/security/ima/ascii_runtime_measurements is filling up kernel memory. Please reboot to clear.'
+    if $facts['ima_log_size'] {
+      if $facts['ima_log_size'] >= $log_max_size {
+        reboot_notify { 'ima_log':
+          reason => 'The IMA /sys/kernel/security/ima/ascii_runtime_measurements is filling up kernel memory. Please reboot to clear.'
+        }
       }
     }
   }

--- a/manifests/ima.pp
+++ b/manifests/ima.pp
@@ -76,15 +76,15 @@ class tpm::ima (
 
     if $ima_tcb {
       kernel_parameter { 'ima_tcb':
-        notify => Reboot_notify['ima_reboot']
+        notify   => Reboot_notify['ima_reboot'],
+        bootmode => 'normal'
       }
     }
 
-    # This feature will remain commented out until the generated policy
-    #  can be safely imported. As of now, it makes the system read-only
-    # if $manage_policy {
-    #   include '::tpm::ima::policy'
-    # }
+    # Be very careful with this class it could make the system read-only
+    if $manage_policy {
+      include '::tpm::ima::policy'
+    }
 
     if $facts['ima_log_size'] >= $log_max_size {
       reboot_notify { 'ima_log':
@@ -93,9 +93,9 @@ class tpm::ima (
     }
   }
   else {
-    kernel_parameter { [ 'ima_tcb' ]:
-      ensure => 'absent',
-      notify => Reboot_notify['ima_reboot']
+    kernel_parameter { 'ima_tcb':
+      ensure   => 'absent',
+      bootmode => 'normal'
     }
     kernel_parameter { [ 'ima', 'ima_audit', 'ima_template', 'ima_hash' ]:
       ensure   => 'absent',
@@ -106,6 +106,7 @@ class tpm::ima (
   reboot_notify { 'ima_reboot':
     subscribe => [
       Kernel_parameter['ima'],
+      Kernel_parameter['ima_tcb'],
       Kernel_parameter['ima_audit'],
       Kernel_parameter['ima_template'],
       Kernel_parameter['ima_hash']

--- a/manifests/ima/policy.pp
+++ b/manifests/ima/policy.pp
@@ -104,11 +104,11 @@ class tpm::ima::policy (
   Array[String] $dont_watch_list = [],
 
   # other defaults
-  Boolean $measure_root_read_files = true,
-  Boolean $measure_file_mmap       = true,
-  Boolean $measure_bprm_check      = true,
-  Boolean $measure_module_check    = true,
-  Boolean $appraise_fowner         = true,
+  Boolean $measure_root_read_files = false,
+  Boolean $measure_file_mmap       = false,
+  Boolean $measure_bprm_check      = false,
+  Boolean $measure_module_check    = false,
+  Boolean $appraise_fowner         = false,
 ){
 
   # magic reference is in Kernel documentation Documentation/ABI/testing/ima_policy

--- a/manifests/ima/policy.pp
+++ b/manifests/ima/policy.pp
@@ -109,7 +109,7 @@ class tpm::ima::policy (
   Boolean $measure_bprm_check      = false,
   Boolean $measure_module_check    = false,
   Boolean $appraise_fowner         = false,
-){
+) {
 
   # magic reference is in Kernel documentation Documentation/ABI/testing/ima_policy
   $magic_hash = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tpm",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "SIMP Team",
   "summary": "Manages TPM 1.2, IMA, and TBOOT",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_tpm_ima_spec.rb
+++ b/spec/acceptance/suites/default/00_tpm_ima_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper_acceptance'
+require 'json'
+
+test_name 'tpm::ima class'
+
+describe 'tpm::ima class' do
+  hosts.each do |host|
+    it 'should set a root password' do
+      on(host, "sed -i 's/enforce_for_root//g' /etc/pam.d/*")
+      on(host, 'echo "root:password" | chpasswd --crypt-method SHA256')
+    end
+  end
+
+  context 'normal, loose rules' do
+    hosts.each do |host|
+      manifest = <<-EOF
+        include 'tpm'
+        class { 'tpm::ima':
+          manage_policy => true
+        }
+      EOF
+
+      it 'should run puppet' do
+        apply_manifest_on(host, manifest, catch_failures: true)
+      end
+
+      it 'should run puppet idempotently' do
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+
+      it 'should run puppet idempotently after a reboot' do
+        # reboot to apply kernel_parameter settings
+        host.reboot
+        # the mount will need to be reset
+        apply_manifest_on(host, manifest, catch_failures: true)
+
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+      it 'should not lock up the filesystem' do
+        on(host, "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 1000 | head -n 10000 > /root/hugefile")
+        on(host, 'head -15 /sys/kernel/security/ima/ascii_runtime_measurements')
+        on(host, 'ls -la ~')
+      end
+    end
+  end
+
+  context 'stricter rules' do
+    hosts.each do |host|
+      manifest = <<-EOF
+        include 'tpm'
+        include 'tpm::ima'
+        class { 'tpm::ima::policy':
+          measure_root_read_files => true,
+          measure_file_mmap       => true,
+          measure_bprm_check      => true,
+          measure_module_check    => true,
+          appraise_fowner         => true,
+        }
+      EOF
+
+      it 'should run puppet' do
+        apply_manifest_on(host, manifest, catch_failures: true)
+      end
+
+      it 'should run puppet idempotently' do
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+
+      it 'should run puppet idempotently after a reboot' do
+        # reboot to apply kernel_parameter settings
+        host.reboot
+        # the mount will need to be reset
+        apply_manifest_on(host, manifest, catch_failures: true)
+
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+      it 'should not lock up the filesystem' do
+        on(host, "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 1000 | head -n 10000 > /root/hugefile")
+        on(host, 'head -15 /sys/kernel/security/ima/ascii_runtime_measurements')
+        on(host, 'ls -la ~')
+      end
+    end
+  end
+
+  context 'even more strict rules' do
+    hosts.each do |host|
+      manifest = <<-EOF
+        include 'tpm'
+        include 'tpm::ima'
+        class { 'tpm::ima::policy':
+          measure_root_read_files    => true,
+          measure_file_mmap          => true,
+          measure_bprm_check         => true,
+          measure_module_check       => true,
+          appraise_fowner            => true,
+          dont_watch_rpm_var_cache_t => false,
+          dont_watch_puppet_log_t    => false,
+          dont_watch_lastlog_t       => false,
+        }
+      EOF
+
+      it 'should run puppet' do
+        apply_manifest_on(host, manifest, catch_failures: true)
+      end
+
+      it 'should run puppet idempotently' do
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+
+      it 'should run puppet idempotently after a reboot' do
+        # reboot to apply kernel_parameter settings
+        host.reboot
+        # the mount will need to be reset
+        apply_manifest_on(host, manifest, catch_failures: true)
+
+        apply_manifest_on(host, manifest, catch_changes: true)
+      end
+
+      it 'may lock up the filesystem' do
+        on(host, 'yum install -y tree')
+        host.reboot
+        on(host, 'head -15 /sys/kernel/security/ima/ascii_runtime_measurements')
+        on(host, 'ls -la ~')
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/nodesets/default.yml
+++ b/spec/acceptance/suites/default/nodesets/default.yml
@@ -1,0 +1,21 @@
+HOSTS:
+  server-el7:
+    roles:
+      - server
+      - default
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+  server-el6:
+    roles:
+      - server
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type:      aio
+  vagrant_memsize: 512
+  synced_folder: disabled
+# vb_gui: true

--- a/spec/classes/ima_spec.rb
+++ b/spec/classes/ima_spec.rb
@@ -5,19 +5,19 @@ describe 'tpm::ima' do
     context "on #{os}" do
 
       let(:params) {{
-        :mount_dir     => '/sys/kernel/security',
-        :ima_audit     => false,
-        :ima_template  => 'ima-ng',
-        :ima_hash      => 'sha256',
-        :ima_tcb       => true,
-        :manage_policy => false,
+        mount_dir:     '/sys/kernel/security',
+        ima_audit:     false,
+        ima_template:  'ima-ng',
+        ima_hash:      'sha256',
+        ima_tcb:       true,
+        manage_policy: false,
       }}
 
       let(:facts) do
-        os_facts.merge({
-          :cmdline      => { 'ima' => 'on' },
-          :ima_log_size => 29000000
-        })
+        os_facts.merge(
+          cmdline:      { 'ima' => 'on' },
+          ima_log_size: 29000000
+        )
       end
 
       context 'with default params' do
@@ -27,47 +27,44 @@ describe 'tpm::ima' do
         # it { is_expected.not_to contain_class('::tpm::ima::policy') }
 
         it do
-          is_expected.to contain_mount(params[:mount_dir]).with({
-            'ensure'   => 'mounted',
-            'atboot'   => true,
-            'device'   => 'securityfs',
-            'fstype'   => 'securityfs',
-            'target'   => '/etc/fstab',
-            'remounts' => true,
-            'options'  => 'defaults',
-            'dump'     => '0',
-            'pass'     => '0'
-          })
+          is_expected.to contain_mount(params[:mount_dir]).with(
+            ensure:   'mounted',
+            atboot:   true,
+            device:   'securityfs',
+            fstype:   'securityfs',
+            target:   '/etc/fstab',
+            remounts: true,
+            options:  'defaults',
+            dump:     '0',
+            pass:     '0'
+          )
         end
       end
 
       context 'should tell the user to reboot when the ima log is filling up' do
         let(:facts) do
-          os_facts.merge({
-            :ima_log_size => 50000002
-          })
+          os_facts.merge( ima_log_size: 50000002 )
         end
-        let(:params) {{ :log_max_size => 50000000 }}
+        let(:params) {{ log_max_size: 50000000 }}
 
+        it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_reboot_notify('ima_log') }
       end
 
       context 'should only manage ima policy when asked' do
         let(:params) {{
-          :manage_policy => true,
-          :enable        => true,
+          enable:        true,
+          manage_policy: true,
         }}
-        it do
-          skip('This is commented out for compatability reasons, like read-only filesystems')
-          is_expected.to contain_class('::tpm::ima::policy')
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('tpm::ima::policy') }
       end
 
       context 'without_ima_enabled' do
         let(:facts) do
           os_facts.merge({
-            :cmdline => { 'foo' => 'bar' },
-            :ima_log_size => 29000000
+            cmdline:      { 'foo' => 'bar' },
+            ima_log_size: 29000000
           })
         end
 
@@ -86,7 +83,7 @@ describe 'tpm::ima' do
       end
 
       context 'disabling_ima' do
-        let(:params) {{ :enable => false }}
+        let(:params) {{ enable: false }}
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_reboot_notify('ima_reboot') }

--- a/spec/files/custom_ima_policy.conf
+++ b/spec/files/custom_ima_policy.conf
@@ -81,8 +81,3 @@ dont_appraise obj_type=var_log_t
 dont_measure obj_type=wtmp_t
 dont_appraise obj_type=wtmp_t
 # other defaults
-measure func=BPRM_CHECK
-measure func=FILE_MMAP mask=MAY_EXEC
-measure func=FILE_CHECK mask=MAY_READ uid=0
-measure func=MODULE_CHECK uid=0
-appraise fowner=0

--- a/spec/files/default_ima_policy.conf
+++ b/spec/files/default_ima_policy.conf
@@ -75,8 +75,3 @@ dont_appraise obj_type=var_log_t
 dont_measure obj_type=wtmp_t
 dont_appraise obj_type=wtmp_t
 # other defaults
-measure func=BPRM_CHECK
-measure func=FILE_MMAP mask=MAY_EXEC
-measure func=FILE_CHECK mask=MAY_READ uid=0
-measure func=MODULE_CHECK uid=0
-appraise fowner=0

--- a/spec/files/other_ima_policy.conf
+++ b/spec/files/other_ima_policy.conf
@@ -8,6 +8,9 @@ dont_appraise fsmagic=0x1cd1
 # kernel fsmagic 0x27e0eb
 dont_measure fsmagic=0x27e0eb
 dont_appraise fsmagic=0x27e0eb
+# kernel fsmagic 0x42494e4d
+dont_measure fsmagic=0x42494e4d
+dont_appraise fsmagic=0x42494e4d
 # kernel fsmagic 0x62656572
 dont_measure fsmagic=0x62656572
 dont_appraise fsmagic=0x62656572
@@ -72,3 +75,8 @@ dont_appraise obj_type=var_log_t
 dont_measure obj_type=wtmp_t
 dont_appraise obj_type=wtmp_t
 # other defaults
+measure func=BPRM_CHECK
+measure func=FILE_MMAP mask=MAY_EXEC
+measure func=FILE_CHECK mask=MAY_READ uid=0
+measure func=MODULE_CHECK uid=0
+appraise fowner=0

--- a/spec/files/selinux_ima_policy.conf
+++ b/spec/files/selinux_ima_policy.conf
@@ -72,8 +72,3 @@ dont_appraise obj_type=var_log_t
 dont_measure obj_type=wtmp_t
 dont_appraise obj_type=wtmp_t
 # other defaults
-measure func=BPRM_CHECK
-measure func=FILE_MMAP mask=MAY_EXEC
-measure func=FILE_CHECK mask=MAY_READ uid=0
-measure func=MODULE_CHECK uid=0
-appraise fowner=0


### PR DESCRIPTION
- tpm::ima::policy was not previously callable from tpm::ima
- tpm::ima::policy will now disable many default IMA checks by default
- Add essential acceptance test

SIMP-4228 #close
  