### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.1.1-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+
 * Thu Sep 13 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.1.0-0
 - Added support for tboot V1.9.6 and removed support for tboot.1.9.4.
   Use pupmod-simp-tpm 1.1.0 if tboot v1.9.4 is required.

--- a/manifests/ownership.pp
+++ b/manifests/ownership.pp
@@ -19,7 +19,7 @@
 #
 class tpm::ownership (
   Boolean                                $owned          = true,
-  Variant[Enum['well-known'],String[20]] $owner_pass     = passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
+  Variant[Enum['well-known'],String[20]] $owner_pass     = simplib::passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
   Optional[String]                       $srk_pass       = undef,
   Boolean                                $advanced_facts = false
 ) {

--- a/manifests/pkcs11.pp
+++ b/manifests/pkcs11.pp
@@ -8,8 +8,8 @@
 # @param user_pin 4-8 character password used for the user pin.
 #
 class tpm::pkcs11 (
-  String $so_pin   = passgen( "${facts['fqdn']}_pkcs_so_pin", { 'length' => 8 } ),
-  String $user_pin = passgen( "${facts['fqdn']}_pkcs_user_pin", { 'length' => 8 } ),
+  String $so_pin   = simplib::passgen( "${facts['fqdn']}_pkcs_so_pin", { 'length' => 8 } ),
+  String $user_pin = simplib::passgen( "${facts['fqdn']}_pkcs_user_pin", { 'length' => 8 } ),
 ){
   ##################################################################################################################
   # Here's a nice doc on how to set up the PKCS #11 interface

--- a/manifests/tboot.pp
+++ b/manifests/tboot.pp
@@ -38,7 +38,7 @@ class tpm::tboot (
   String               $rsync_source            = "tboot_${::environment}/",
   Optional[String]     $rsync_server            = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
   Integer              $rsync_timeout           = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => 1 }),
-  String               $owner_password          = passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
+  String               $owner_password          = simplib::passgen( "${facts['fqdn']}_tpm0_owner_pass", { 'length' => 20 } ),
   Array[String]        $tboot_boot_options      = ['logging=serial,memory,vga','min_ram=0x2000000'],
   Array[String]        $additional_boot_options = ['intel_iommu=on'],
   Stdlib::AbsolutePath $policy_script           = '/root/txt/create_lcp_boot_policy.sh',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tpm",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "SIMP Team",
   "summary": "Manages TPM 1.2 and TBOOT",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/rsync",


### PR DESCRIPTION
Use simplib::passgen() in lieu of passgen(), a deprecated simplib
Puppet 3 function.

SIMP-6110 #comment pupmod-simp-tpm