### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,17 +3,11 @@ fixtures:
   repositories:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     ima: https://github.com/simp/pupmod-simp-ima
     rsync: https://github.com/simp/pupmod-simp-rsync
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    yum:
-      repo: https://github.com/simp/puppet-yum
-      ref: v2.1.0
+    yum: https://github.com/simp/puppet-yum
   symlinks:
     tpm: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.1.1-0
 - Use simplib::passgen() in lieu of passgen(), a deprecated simplib
   Puppet 3 function.
+- Expanded the upper limits of the stdlib and yum Puppet module versions
 
 * Thu Sep 13 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.1.0-0
 - Added support for tboot V1.9.6 and removed support for tboot.1.9.4.

--- a/metadata.json
+++ b/metadata.json
@@ -30,11 +30,11 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "puppet/yum",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limits of the stdlib and yum Puppet module versions

SIMP-6213 #comment pupmod-simp-tpm