### PR TITLE
Remove uses of File.exists?

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 18 2023 Steven Pritchard <steve@sicura.us> - 3.5.1
+- Replace calls to `File.exists?` with `File.exist?` for compatibility with
+  Ruby 3
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 3.5.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/lib/facter/has_tpm.rb
+++ b/lib/facter/has_tpm.rb
@@ -1,6 +1,6 @@
 # Detects whether or not the machine has a TPM
 Facter.add('has_tpm') do
   setcode do
-    File.exists?('/dev/tpm0')
+    File.exist?('/dev/tpm0')
   end
 end

--- a/lib/facter/tpm/util.rb
+++ b/lib/facter/tpm/util.rb
@@ -180,7 +180,7 @@ module Facter
           raw = get_pubek_unowned
           out['_status'] = 'success: tpm unowned'
         else
-          if File.exists?(pass_file)
+          if File.exist?(pass_file)
             owner_pass = Facter::Core::Execution.execute("cat #{pass_file} 2> /dev/null")
             if owner_pass.eql? ""
               out['_status'] = 'error: the password file is empty'

--- a/lib/puppet/provider/tpmtoken/pkcsconf.rb
+++ b/lib/puppet/provider/tpmtoken/pkcsconf.rb
@@ -128,7 +128,7 @@ Puppet::Type.type(:tpmtoken).provide :pkcsconf do
   def flush
     if @property_flush[:ensure] == :absent
       f = File.expand_path('/var/lib/opencryptoki/tpm/root')
-      FileUtils.rm_rf(f) if File.exists?(f)
+      FileUtils.rm_rf(f) if File.exist?(f)
       debug("Deleted interface #{resource[:name]} folder at #{f}")
       @property_hash[:ensure] = :absent
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tpm",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": "SIMP Team",
   "summary": "Manages TPM 1.2 and TBOOT",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,7 +11,7 @@ describe 'tpm' do
       end
 
       # before(:each) do
-      #   File.stubs(:exists?).with('/dev/tpm0').returns(true)
+      #   File.stubs(:exist?).with('/dev/tpm0').returns(true)
       # end
 
       context 'with default parameters and no physical TPM' do

--- a/spec/unit/facter/has_tpm_spec.rb
+++ b/spec/unit/facter/has_tpm_spec.rb
@@ -9,14 +9,14 @@ describe 'has_tpm', :type => :fact do
 
   context 'the required file is not present' do
     it 'should return nil' do
-      File.stubs(:exists?).with('/dev/tpm0').returns false
+      File.stubs(:exist?).with('/dev/tpm0').returns false
       expect(Facter.fact(:has_tpm).value).to eq false
     end
   end
 
   context 'the required file is present' do
     it 'should return true' do
-      File.stubs(:exists?).with('/dev/tpm0').returns true
+      File.stubs(:exist?).with('/dev/tpm0').returns true
       expect(Facter.fact(:has_tpm).value).to eq true
     end
   end

--- a/spec/unit/facter/tpm_spec.rb
+++ b/spec/unit/facter/tpm_spec.rb
@@ -177,7 +177,7 @@ describe 'tpm', :type => :fact do
       context 'tpm is owned' do
         before(:each) do
           @tpm_fact.stubs(:get_pubek_owned).returns File.read('spec/files/tpm/tpm_getpubek.txt')
-          File.stubs(:exists?).with('/dev/null/simp/tpm_ownership_owner_pass').returns true
+          File.stubs(:exist?).with('/dev/null/simp/tpm_ownership_owner_pass').returns true
           Facter::Core::Execution.stubs(:execute).with('cat /dev/null/simp/tpm_ownership_owner_pass 2> /dev/null').returns 'twentycharacters0000'
         end
         let(:params) {{ 'enabled' => 1, 'owned' => 1 }}

--- a/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
+++ b/spec/unit/puppet/provider/tpm_ownership/trousers_spec.rb
@@ -45,18 +45,18 @@ describe Puppet::Type.type(:tpm_ownership).provider(:trousers) do
     let(:loc) { '/tmp' }
     after :each do
       file = "#{loc}/simp/tpm_ownership_owner_pass"
-      FileUtils.rm(file) if File.exists? file
+      FileUtils.rm(file) if File.exist? file
     end
 
     context 'with advanced_facts => false' do
       it 'should not do a thing' do
-        expect(File.exists?("#{loc}/simp/tpm_ownership_owner_pass")).to be_falsey
+        expect(File.exist?("#{loc}/simp/tpm_ownership_owner_pass")).to be_falsey
       end
     end
     context 'with advanced_facts => true' do
       it 'should drop off the password file' do
         expect(provider.dump_owner_pass(loc)).to match(/twentycharacters0000/)
-        expect(File.exists?("#{loc}/simp/tpm_ownership_owner_pass")).to be_truthy
+        expect(File.exist?("#{loc}/simp/tpm_ownership_owner_pass")).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Replace calls to `File.exists?` with `File.exist?` for compatibility with Ruby 3

Closes #97